### PR TITLE
Unittest2 is unnecessary in Python 2.7

### DIFF
--- a/djcelery/tests/test_backends/test_cache.py
+++ b/djcelery/tests/test_backends/test_cache.py
@@ -1,5 +1,8 @@
 import sys
-import unittest2 as unittest
+import unittest
+# skip and many other features were added to unittest in python 2.7
+if 'skip' not in dir(unittest):
+    import unittest2 as unittest
 
 from datetime import timedelta
 

--- a/djcelery/tests/test_backends/test_database.py
+++ b/djcelery/tests/test_backends/test_database.py
@@ -1,4 +1,7 @@
-import unittest2 as unittest
+import unittest
+# skip and many other features were added to unittest in python 2.7
+if 'skip' not in dir(unittest):
+    import unittest2 as unittest
 
 from datetime import datetime, timedelta
 

--- a/djcelery/tests/test_conf.py
+++ b/djcelery/tests/test_conf.py
@@ -1,4 +1,7 @@
-import unittest2 as unittest
+import unittest
+# skip and many other features were added to unittest in python 2.7
+if 'skip' not in dir(unittest):
+    import unittest2 as unittest
 
 from django.conf import settings
 

--- a/djcelery/tests/test_discovery.py
+++ b/djcelery/tests/test_discovery.py
@@ -1,4 +1,7 @@
-import unittest2 as unittest
+import unittest
+# skip and many other features were added to unittest in python 2.7
+if 'skip' not in dir(unittest):
+    import unittest2 as unittest
 
 from django.conf import settings
 

--- a/djcelery/tests/test_loaders.py
+++ b/djcelery/tests/test_loaders.py
@@ -1,4 +1,7 @@
-import unittest2 as unittest
+import unittest
+# skip and many other features were added to unittest in python 2.7
+if 'skip' not in dir(unittest):
+    import unittest2 as unittest
 
 from celery import loaders
 

--- a/djcelery/tests/test_models.py
+++ b/djcelery/tests/test_models.py
@@ -1,4 +1,8 @@
-import unittest2 as unittest
+import unittest
+# skip and many other features were added to unittest in python 2.7
+if 'skip' not in dir(unittest):
+    import unittest2 as unittest
+
 from datetime import datetime, timedelta
 
 from celery import conf

--- a/djcelery/tests/test_schedulers.py
+++ b/djcelery/tests/test_schedulers.py
@@ -1,4 +1,7 @@
-import unittest2 as unittest
+import unittest
+# skip and many other features were added to unittest in python 2.7
+if 'skip' not in dir(unittest):
+    import unittest2 as unittest
 
 from datetime import datetime, timedelta
 from itertools import count

--- a/djcelery/tests/test_snapshot.py
+++ b/djcelery/tests/test_snapshot.py
@@ -1,4 +1,7 @@
-import unittest2 as unittest
+import unittest
+# skip and many other features were added to unittest in python 2.7
+if 'skip' not in dir(unittest):
+    import unittest2 as unittest
 
 from datetime import datetime
 from itertools import count

--- a/djcelery/tests/test_worker_job.py
+++ b/djcelery/tests/test_worker_job.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-import unittest2 as unittest
+import unittest
+# skip and many other features were added to unittest in python 2.7
+if 'skip' not in dir(unittest):
+    import unittest2 as unittest
 
 from django.core import cache
 


### PR DESCRIPTION
The unit test suite will fail if unittest2 is not installed. This is unnecessary in Python 2.7, since the standard library already includes all of the new features.

The attached patch is trivial, but it fixed the failing tests on my machine. It uses introspection to check the unittest module for a feature added in 2.7. If it is not available, then we can fall back on unittest2.
