### PR TITLE
transaction.commit_manually error

### DIFF
--- a/djcelery/schedulers.py
+++ b/djcelery/schedulers.py
@@ -139,7 +139,7 @@ class DatabaseScheduler(Scheduler):
             self.flush()
         return new_entry
 
-    @transaction.commit_manually()
+    @transaction.commit_manually
     def flush(self):
         self.logger.debug("Writing dirty entries...")
         if not self._dirty:


### PR DESCRIPTION
I was getting an error when I tried to run `./manage.py celerybeat -S djcelery.schedulers.DatabaseScheduler`

Looks like there was a typo where someone had `@transaction.commit_manually()` instead of `@transaction.commit_manually`
