### PR TITLE
djcelerymon Django 1.2.x compatibility fix

### DIFF
--- a/djcelery/management/commands/djcelerymon.py
+++ b/djcelery/management/commands/djcelerymon.py
@@ -22,7 +22,7 @@ class WebserverThread(Thread):
 
     def run(self):
         options = dict(self.options, use_reloader=False)
-        runserver.Command().handle(self.addrport, *self.args, **options)
+        runserver.Command().execute(addrport=self.addrport, *self.args, **options)
 
 
 class Command(CeleryCommand):


### PR DESCRIPTION
When calling ./manage.py djcelerymon the BaseCommand.execute method is bypassed which has a little bits of setup for Command.handle
