### PR TITLE
Comparing booleans with integers doesn't work in PostgreSQL

### DIFF
--- a/djcelery/managers.py
+++ b/djcelery/managers.py
@@ -204,6 +204,6 @@ class TaskStateManager(ExtendedManager):
 
     def purge(self):
         cursor = self.connection_for_write().cursor()
-        cursor.execute("DELETE FROM %s WHERE hidden=1" % (
+        cursor.execute("DELETE FROM %s WHERE hidden = true" % (
                         self.model._meta.db_table, ))
         transaction.commit_unless_managed()


### PR DESCRIPTION
The stacktrace:

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.6/dist-packages/celery/utils/timer2.py", line 155, in apply_entry
    entry()
  File "/usr/local/lib/python2.6/dist-packages/celery/utils/timer2.py", line 41, in __call__
    return self.fun(*self.args, **self.kwargs)
  File "/usr/local/lib/python2.6/dist-packages/celery/utils/timer2.py", line 229, in _reschedules
    return fun(*args, **kwargs)
  File "/usr/local/lib/python2.6/dist-packages/celery/events/snapshot.py", line 45, in cleanup
    self.on_cleanup()
  File "/usr/local/lib/python2.6/dist-packages/djcelery/snapshot.py", line 133, in on_cleanup
    self.TaskState.objects.purge()
  File "/usr/local/lib/python2.6/dist-packages/djcelery/managers.py", line 194, in purge
    self.model._meta.db_table, ))

DatabaseError: operator does not exist: boolean = integer
LINE 1: DELETE FROM djcelery_taskstate WHERE hidden=1
```

Changing the query to `hidden = true` works without a problem in both PostgreSQL and MySQL.

PS: Is there any specific reason for executing manual deletes instead of something like: `self.model.objects.all().filter(hidden=True).delete()`?
