### PR TITLE
Replace function based test runner with class based

### DIFF
--- a/djcelery/contrib/test_runner.py
+++ b/djcelery/contrib/test_runner.py
@@ -1,20 +1,21 @@
 from django.conf import settings
-from django.test.simple import run_tests as run_tests_orig
+from django.test.simple import DjangoTestSuiteRunner
 
 USAGE = """\
 Custom test runner to allow testing of celery delayed tasks.
 """
 
 
-def run_tests(test_labels, *args, **kwargs):
-    """Django test runner allowing testing of celery delayed tasks.
+class DjangoCeleryTestSuiteRunner(DjangoTestSuiteRunner):
+    def run_tests(self, test_labels, *args, **kwargs):
+        """Django test runner allowing testing of celery delayed tasks.
 
-    All tasks are run locally, not in a worker.
+        All tasks are run locally, not in a worker.
 
-    To use this runner set ``settings.TEST_RUNNER``::
+        To use this runner set ``settings.TEST_RUNNER``::
 
-        TEST_RUNNER = "celery.contrib.test_runner.run_tests"
+            TEST_RUNNER = "celery.contrib.test_runner.DjangoCeleryTestSuiteRunner"
 
-    """
-    settings.CELERY_ALWAYS_EAGER = True
-    return run_tests_orig(test_labels, *args, **kwargs)
+        """
+        settings.CELERY_ALWAYS_EAGER = True
+        return super(DjangoCeleryTestSuiteRunner, self).run_tests(test_labels, *args, **kwargs)


### PR DESCRIPTION
Replace function based test runner with class based. Test runners in Django 1.2 and above are a class, not a  function. I noticed there already is a pull request regarding this issue, but it seem it has been around for a while. 

This commit simply redefines the function based test runner to a class based one. Nothing fancy. It might make sense provide two different ones based on which version of django the user is using.  
