### PR TITLE
Fixed config for sphinxcontrib-issuetracker >= 0.8

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,6 +77,5 @@ html_sidebars = {
 ### Issuetracker
 
 issuetracker = "github"
-issuetracker_user = "ask"
-issuetracker_project = "celery"
+issuetracker_project = "ask/django-celery"
 issuetracker_issue_pattern = r'[Ii]ssue #(\d+)'


### PR DESCRIPTION
As of sphinxcontrib-issuetracker 0.8, project name includes username. So instead of separately specifying ask as username, and django-celery as project, it's now 'ask/django-celery'. Also, pointed the issuetracker at django-celery instead of celery.
