### PR TITLE
Removed unused variable (deprecated in django?)

### DIFF
--- a/djcelery/admin.py
+++ b/djcelery/admin.py
@@ -171,7 +171,6 @@ class TaskMonitor(ModelMonitor):
             "object_name": force_unicode(opts.verbose_name),
             "action_checkbox_name": helpers.ACTION_CHECKBOX_NAME,
             "opts": opts,
-            "root_path": self.admin_site.root_path,
             "app_label": app_label,
         }
 


### PR DESCRIPTION
Seems that it doesn't exist in django 1.4 and we don't need it anyway (not used in any templates)
