### PR TITLE
Fix ignore_exists signature so that unit test database can be created. We can't fake these

### DIFF
--- a/djcelery/migrations/0001_initial.py
+++ b/djcelery/migrations/0001_initial.py
@@ -8,7 +8,7 @@ from django.db import models
 from django.db.utils import DatabaseError
 
 
-def ignore_exists(self, fun, *args, **kwargs):
+def ignore_exists(fun, *args, **kwargs):
     try:
         fun(*args, **kwargs)
     except DatabaseError, exc:


### PR DESCRIPTION
Fix ignore_exists signature so that unit test database can be created.

Although we can fake migrations on prod and dev servers as proposed here https://github.com/ask/django-celery/issues/87 , we can't fake the unit test database migrations.
