### PR TITLE
Remove the "self" argument from ignore_exists, which was causing initial...

### DIFF
--- a/djcelery/migrations/0001_initial.py
+++ b/djcelery/migrations/0001_initial.py
@@ -8,7 +8,7 @@ from django.db import models
 from django.db.utils import DatabaseError
 
 
-def ignore_exists(self, fun, *args, **kwargs):
+def ignore_exists(fun, *args, **kwargs):
     try:
         fun(*args, **kwargs)
     except DatabaseError, exc:


### PR DESCRIPTION
... migrations to fail

Because ignore_exists is a function not a class method, it does not need a self argument.
Additionally, the Migration.forwards method does not pass "self" to the function.

Fix thanks to Jason Michalski.
