### PR TITLE
Suggested 0001_initial.py change for Django 1.1.2 support

### DIFF
--- a/djcelery/migrations/0001_initial.py
+++ b/djcelery/migrations/0001_initial.py
@@ -5,7 +5,7 @@ import datetime
 from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
-from django.db.utils import DatabaseError
+from django.db import DatabaseError
 
 
 def ignore_exists(fun, *args, **kwargs):


### PR DESCRIPTION
I'm working with an old project stuck at Django 1.1.2, and ran into a problem with the 0001_initial.py migration importing django.db.utils, since Django 1.1.2 doesn't have a a db.util.py.   However, it does surface DatabaseError django.db.

I also checked with Django-1.3.1 that 'from django.db import DatabaseError' continues to work there as well.
