### PR TITLE
Removed ignore_exists function again as it causes pain, fixes #95

### DIFF
--- a/djcelery/migrations/0001_initial.py
+++ b/djcelery/migrations/0001_initial.py
@@ -8,60 +8,51 @@ from django.db import models
 from django.db import DatabaseError
 
 
-def ignore_exists(fun, *args, **kwargs):
-    try:
-        fun(*args, **kwargs)
-    except DatabaseError, exc:
-        if "exists" in str(exc):
-            return False
-        raise
-    return True
-
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
 
         # Adding model 'TaskMeta'
-        if ignore_exists(db.create_table, 'celery_taskmeta', (
+        db.create_table('celery_taskmeta', (
                 ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
                 ('task_id', self.gf('django.db.models.fields.CharField')(unique=True, max_length=255)),
                 ('status', self.gf('django.db.models.fields.CharField')(default='PENDING', max_length=50)),
                 ('result', self.gf('picklefield.fields.PickledObjectField')(default=None, null=True)),
                 ('date_done', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, blank=True)),
-                ('traceback', self.gf('django.db.models.fields.TextField')(null=True, blank=True)),)):
-            db.send_create_signal('djcelery', ['TaskMeta'])
+                ('traceback', self.gf('django.db.models.fields.TextField')(null=True, blank=True)),))
+        db.send_create_signal('djcelery', ['TaskMeta'])
 
         # Adding model 'TaskSetMeta'
-        if ignore_exists(db.create_table, 'celery_tasksetmeta', (
+        db.create_table('celery_tasksetmeta', (
                 ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
                 ('taskset_id', self.gf('django.db.models.fields.CharField')(unique=True, max_length=255)),
                 ('result', self.gf('picklefield.fields.PickledObjectField')()),
-                ('date_done', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, blank=True)),)):
-            db.send_create_signal('djcelery', ['TaskSetMeta'])
+                ('date_done', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, blank=True)),))
+        db.send_create_signal('djcelery', ['TaskSetMeta'])
 
         # Adding model 'IntervalSchedule'
-        if ignore_exists(db.create_table, 'djcelery_intervalschedule', (
+        db.create_table('djcelery_intervalschedule', (
                 ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
                 ('every', self.gf('django.db.models.fields.IntegerField')()),
-                ('period', self.gf('django.db.models.fields.CharField')(max_length=24)),)):
-            db.send_create_signal('djcelery', ['IntervalSchedule'])
+                ('period', self.gf('django.db.models.fields.CharField')(max_length=24)),))
+        db.send_create_signal('djcelery', ['IntervalSchedule'])
 
         # Adding model 'CrontabSchedule'
-        if ignore_exists(db.create_table, 'djcelery_crontabschedule', (
+        db.create_table('djcelery_crontabschedule', (
                 ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
                 ('minute', self.gf('django.db.models.fields.CharField')(default='*', max_length=64)),
                 ('hour', self.gf('django.db.models.fields.CharField')(default='*', max_length=64)),
-                ('day_of_week', self.gf('django.db.models.fields.CharField')(default='*', max_length=64)),)):
-            db.send_create_signal('djcelery', ['CrontabSchedule'])
+                ('day_of_week', self.gf('django.db.models.fields.CharField')(default='*', max_length=64)),))
+        db.send_create_signal('djcelery', ['CrontabSchedule'])
 
         # Adding model 'PeriodicTasks'
-        if ignore_exists(db.create_table, 'djcelery_periodictasks', (
+        db.create_table('djcelery_periodictasks', (
                 ('ident', self.gf('django.db.models.fields.SmallIntegerField')(default=1, unique=True, primary_key=True)),
-                ('last_update', self.gf('django.db.models.fields.DateTimeField')()),)):
-            db.send_create_signal('djcelery', ['PeriodicTasks'])
+                ('last_update', self.gf('django.db.models.fields.DateTimeField')()),))
+        db.send_create_signal('djcelery', ['PeriodicTasks'])
 
         # Adding model 'PeriodicTask'
-        if ignore_exists(db.create_table, 'djcelery_periodictask', (
+        db.create_table('djcelery_periodictask', (
                 ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
                 ('name', self.gf('django.db.models.fields.CharField')(unique=True, max_length=200)),
                 ('task', self.gf('django.db.models.fields.CharField')(max_length=200)),
@@ -76,18 +67,18 @@ class Migration(SchemaMigration):
                 ('enabled', self.gf('django.db.models.fields.BooleanField')(default=True)),
                 ('last_run_at', self.gf('django.db.models.fields.DateTimeField')(null=True, blank=True)),
                 ('total_run_count', self.gf('django.db.models.fields.PositiveIntegerField')(default=0)),
-                ('date_changed', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, blank=True)),)):
-            db.send_create_signal('djcelery', ['PeriodicTask'])
+                ('date_changed', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, blank=True)),))
+        db.send_create_signal('djcelery', ['PeriodicTask'])
 
         # Adding model 'WorkerState'
-        if ignore_exists(db.create_table, 'djcelery_workerstate', (
+        db.create_table('djcelery_workerstate', (
                 ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
                 ('hostname', self.gf('django.db.models.fields.CharField')(unique=True, max_length=255)),
-                ('last_heartbeat', self.gf('django.db.models.fields.DateTimeField')(null=True, db_index=True)),)):
-            db.send_create_signal('djcelery', ['WorkerState'])
+                ('last_heartbeat', self.gf('django.db.models.fields.DateTimeField')(null=True, db_index=True)),))
+        db.send_create_signal('djcelery', ['WorkerState'])
 
         # Adding model 'TaskState'
-        if ignore_exists(db.create_table, 'djcelery_taskstate', (
+        db.create_table('djcelery_taskstate', (
                 ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
                 ('state', self.gf('django.db.models.fields.CharField')(max_length=64, db_index=True)),
                 ('task_id', self.gf('django.db.models.fields.CharField')(unique=True, max_length=36)),
@@ -102,8 +93,8 @@ class Migration(SchemaMigration):
                 ('runtime', self.gf('django.db.models.fields.FloatField')(null=True)),
                 ('retries', self.gf('django.db.models.fields.IntegerField')(default=0)),
                 ('worker', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['djcelery.WorkerState'], null=True)),
-                ('hidden', self.gf('django.db.models.fields.BooleanField')(default=False, db_index=True)),)):
-            db.send_create_signal('djcelery', ['TaskState'])
+                ('hidden', self.gf('django.db.models.fields.BooleanField')(default=False, db_index=True)),))
+        db.send_create_signal('djcelery', ['TaskState'])
 
 
     def backwards(self, orm):


### PR DESCRIPTION
Unittests run with new PostgreSQL 9.1 transaction behavior fail
because ignore_exists does not roll back properly but leaves
the database transaction in a bad state.

Besides that it is documented([1]) how to upgrade if this error
occurs.  There is no reason to workaround this in such a way.

[1]: in http://packages.python.org/django-celery/changelog.html#upgrading-for-south-users
