### PR TITLE
Change to make django-celery work with Django < 1.3

### DIFF
--- a/djcelery/utils.py
+++ b/djcelery/utils.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from django.conf import settings
 
 # Database-related exceptions.
-from django.db.utils import DatabaseError
+from django.db import DatabaseError
 try:
     import MySQLdb as mysql
     _my_database_errors = (mysql.DatabaseError, )


### PR DESCRIPTION
Same kind of fix as in pull request 92 https://github.com/ask/django-celery/pull/92

Before Django 1.3 import:
`from django.db.utils import DatabaseError`
raises ImportError as in 1.2 and before DatabaseError should be imported:
`from django.db import DatabaseError`
which works in Django 1.3 as well
