### PR TITLE
Update CrontabSchedule Model

### DIFF
--- a/djcelery/migrations/0003_v26_changes.py
+++ b/djcelery/migrations/0003_v26_changes.py
@@ -1,0 +1,112 @@
+# encoding: utf-8
+from __future__ import absolute_import
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Adding field 'CrontabSchedule.day_of_month'
+        db.add_column('djcelery_crontabschedule', 'day_of_month', self.gf('django.db.models.fields.CharField')(default='*', max_length=64), keep_default=False)
+
+        # Adding field 'CrontabSchedule.month_of_year'
+        db.add_column('djcelery_crontabschedule', 'month_of_year', self.gf('django.db.models.fields.CharField')(default='*', max_length=64), keep_default=False)
+
+
+    def backwards(self, orm):
+
+        # Deleting field 'CrontabSchedule.day_of_month'
+        db.delete_column('djcelery_crontabschedule', 'day_of_month')
+
+        # Deleting field 'CrontabSchedule.month_of_year'
+        db.delete_column('djcelery_crontabschedule', 'month_of_year')
+
+
+    models = {
+        'djcelery.crontabschedule': {
+            'Meta': {'object_name': 'CrontabSchedule'},
+            'day_of_month': ('django.db.models.fields.CharField', [], {'default': "'*'", 'max_length': '64'}),
+            'day_of_week': ('django.db.models.fields.CharField', [], {'default': "'*'", 'max_length': '64'}),
+            'hour': ('django.db.models.fields.CharField', [], {'default': "'*'", 'max_length': '64'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'minute': ('django.db.models.fields.CharField', [], {'default': "'*'", 'max_length': '64'}),
+            'month_of_year': ('django.db.models.fields.CharField', [], {'default': "'*'", 'max_length': '64'})
+        },
+        'djcelery.intervalschedule': {
+            'Meta': {'object_name': 'IntervalSchedule'},
+            'every': ('django.db.models.fields.IntegerField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'period': ('django.db.models.fields.CharField', [], {'max_length': '24'})
+        },
+        'djcelery.periodictask': {
+            'Meta': {'object_name': 'PeriodicTask'},
+            'args': ('django.db.models.fields.TextField', [], {'default': "'[]'", 'blank': 'True'}),
+            'crontab': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['djcelery.CrontabSchedule']", 'null': 'True', 'blank': 'True'}),
+            'date_changed': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'exchange': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'expires': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'interval': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['djcelery.IntervalSchedule']", 'null': 'True', 'blank': 'True'}),
+            'kwargs': ('django.db.models.fields.TextField', [], {'default': "'{}'", 'blank': 'True'}),
+            'last_run_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '200'}),
+            'queue': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'routing_key': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'task': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'total_run_count': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'})
+        },
+        'djcelery.periodictasks': {
+            'Meta': {'object_name': 'PeriodicTasks'},
+            'ident': ('django.db.models.fields.SmallIntegerField', [], {'default': '1', 'unique': 'True', 'primary_key': 'True'}),
+            'last_update': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        'djcelery.taskmeta': {
+            'Meta': {'object_name': 'TaskMeta', 'db_table': "'celery_taskmeta'"},
+            'date_done': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'hidden': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'result': ('djcelery.picklefield.PickledObjectField', [], {'default': 'None', 'null': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'PENDING'", 'max_length': '50'}),
+            'task_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'traceback': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'djcelery.tasksetmeta': {
+            'Meta': {'object_name': 'TaskSetMeta', 'db_table': "'celery_tasksetmeta'"},
+            'date_done': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'hidden': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'result': ('djcelery.picklefield.PickledObjectField', [], {}),
+            'taskset_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'})
+        },
+        'djcelery.taskstate': {
+            'Meta': {'ordering': "['-tstamp']", 'object_name': 'TaskState'},
+            'args': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'eta': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'expires': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'hidden': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'kwargs': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'db_index': 'True'}),
+            'result': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'retries': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'runtime': ('django.db.models.fields.FloatField', [], {'null': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '64', 'db_index': 'True'}),
+            'task_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36'}),
+            'traceback': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'tstamp': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'worker': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['djcelery.WorkerState']", 'null': 'True'})
+        },
+        'djcelery.workerstate': {
+            'Meta': {'ordering': "['-last_heartbeat']", 'object_name': 'WorkerState'},
+            'hostname': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_heartbeat': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['djcelery']

--- a/djcelery/models.py
+++ b/djcelery/models.py
@@ -124,6 +124,12 @@ class CrontabSchedule(models.Model):
     day_of_week = models.CharField(_(u"day of week"),
                         max_length=64,
                         default="*")
+    day_of_month = models.CharField(_(u"day of month"),
+                        max_length=64,
+                        default="*")
+    month_of_year = models.CharField(_(u"month of year"),
+                        max_length=64,
+                        default="*")
 
     class Meta:
         verbose_name = _(u"crontab")
@@ -131,22 +137,28 @@ class CrontabSchedule(models.Model):
 
     def __unicode__(self):
         rfield = lambda f: f and str(f).replace(" ", "") or "*"
-        return u"%s %s %s (m/h/d)" % (rfield(self.minute),
-                                      rfield(self.hour),
-                                      rfield(self.day_of_week))
+        return u"%s %s %s %s %s (m/h/d/dM/MY)" % (rfield(self.minute),
+                                                  rfield(self.hour),
+                                                  rfield(self.day_of_week),
+                                                  rfield(self.day_of_month),
+                                                  rfield(self.month_of_year))
 
     @property
     def schedule(self):
         return schedules.crontab(minute=self.minute,
                                 hour=self.hour,
                                 day_of_week=self.day_of_week,
+                                day_of_month=self.day_of_month,
+                                month_of_year=self.month_of_year,
                                 nowfun=now)
 
     @classmethod
     def from_schedule(cls, schedule):
         return cls(minute=schedule._orig_minute,
                    hour=schedule._orig_hour,
-                   day_of_week=schedule._orig_day_of_week)
+                   day_of_week=schedule._orig_day_of_week,
+                   day_of_month=schedule._orig_day_of_month,
+                   month_of_year=schedule._orig_month_of_year)
 
 
 class PeriodicTasks(models.Model):
@@ -224,7 +236,7 @@ class PeriodicTask(models.Model):
         self.exchange = self.exchange or None
         self.routing_key = self.routing_key or None
         self.queue = self.queue or None
-        if self.disabled:
+        if not self.enabled:
             self.last_run_at = None
         super(PeriodicTask, self).save(*args, **kwargs)
 

--- a/djcelery/picklefield.py
+++ b/djcelery/picklefield.py
@@ -97,4 +97,4 @@ except ImportError:
     pass
 else:
     add_introspection_rules([],
-            ['r"^djcelery\.picklefield\.PickledObjectField'])
+            [r'^djcelery\.picklefield\.PickledObjectField'])

--- a/djcelery/tests/test_schedulers.py
+++ b/djcelery/tests/test_schedulers.py
@@ -225,11 +225,13 @@ class test_models(unittest.TestCase):
         self.assertEqual(unicode(CrontabSchedule(minute=3,
                                                  hour=3,
                                                  day_of_week=None)),
-                         "3 3 * (m/h/d)")
+                         "3 3 * * * (m/h/d/dM/MY)")
         self.assertEqual(unicode(CrontabSchedule(minute=3,
                                                  hour=3,
-                                                 day_of_week=None)),
-                         "3 3 * (m/h/d)")
+                                                 day_of_week="tue",
+                                                 day_of_month="*/2",
+                                                 month_of_year="4,6")),
+                         "3 3 tue */2 4,6 (m/h/d/dM/MY)")
 
     def test_PeriodicTask_unicode_interval(self):
         p = create_model_interval(schedule(timedelta(seconds=10)))
@@ -240,29 +242,37 @@ class test_models(unittest.TestCase):
         p = create_model_crontab(crontab(hour="4, 5", day_of_week="4, 5",
                                  nowfun=now))
         self.assertEqual(unicode(p),
-                        "%s: * 4,5 4,5 (m/h/d)" % p.name)
+                        "%s: * 4,5 4,5 * * (m/h/d/dM/MY)" % p.name)
 
     def test_PeriodicTask_schedule_property(self):
         p1 = create_model_interval(schedule(timedelta(seconds=10)))
         s1 = p1.schedule
         self.assertEqual(timedelta_seconds(s1.run_every), 10)
 
-        p2 = create_model_crontab(crontab(hour="4, 5", minute="10,20,30",
+        p2 = create_model_crontab(crontab(hour="4, 5",
+                                          minute="10,20,30",
+                                          day_of_month="1-7",
+                                          month_of_year="*/3",
                                           nowfun=now))
         s2 = p2.schedule
         self.assertSetEqual(s2.hour, set([4, 5]))
         self.assertSetEqual(s2.minute, set([10, 20, 30]))
         self.assertSetEqual(s2.day_of_week, set([0, 1, 2, 3, 4, 5, 6]))
+        self.assertSetEqual(s2.day_of_month, set([1, 2, 3, 4, 5, 6, 7]))
+        self.assertSetEqual(s2.month_of_year, set([1, 4, 7, 10]))
 
     def test_PeriodicTask_unicode_no_schedule(self):
         p = create_model()
         self.assertEqual(unicode(p), "%s: {no schedule}" % p.name)
 
     def test_CrontabSchedule_schedule(self):
-        s = CrontabSchedule(minute="3, 7", hour="3, 4", day_of_week="*")
+        s = CrontabSchedule(minute="3, 7", hour="3, 4", day_of_week="*",
+                            day_of_month="1, 16", month_of_year="1, 7")
         self.assertEqual(s.schedule.minute, set([3, 7]))
         self.assertEqual(s.schedule.hour, set([3, 4]))
         self.assertEqual(s.schedule.day_of_week, set([0, 1, 2, 3, 4, 5, 6]))
+        self.assertEqual(s.schedule.day_of_month, set([1, 16]))
+        self.assertEqual(s.schedule.month_of_year, set([1, 7]))
 
 
 class test_model_PeriodicTasks(unittest.TestCase):


### PR DESCRIPTION
Add day of month and month of year fields to CrontabSchedule model to match crontab feature request (celery issue 569) supplied (celery issue 686).  Added database migration from South after fixing minor typo in picklefield.py that kept South from being able to do a schemamigration.  Attempted to update tests, but couldn't get all of the tests to run locally, so unsure if correct (failing tests were not the ones updated, however).
