### PR TITLE
Fixed #139 - Django-celery 2.5.5: celerycam shows a stacktrace

### DIFF
--- a/djcelery/models.py
+++ b/djcelery/models.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 from time import time, mktime
 
 import django
@@ -306,6 +306,11 @@ class TaskState(models.Model):
         verbose_name_plural = _(u"tasks")
         get_latest_by = "tstamp"
         ordering = ["-tstamp"]
+
+    def save(self, *args, **kwargs):
+        if self.eta is not None:
+            self.eta = datetime.utcfromtimestamp(mktime(self.eta.timetuple()))
+        super(TaskState, self).save(*args, **kwargs)
 
     def __unicode__(self):
         name = self.name or "UNKNOWN"


### PR DESCRIPTION
See also https://groups.google.com/forum/#!msg/celery-users/Eb-DpLw77R8/rN264yWmXswJ

The problem is caused by MySQL's inability to store tz-aware timestamps.

This change makes `TaskState` convert the `eta` attribute to UTC before saving.
