### PR TITLE
Extra fix for #149 works for MySQL also 

### DIFF
--- a/djcelery/migrations/0002_v25_changes.py
+++ b/djcelery/migrations/0002_v25_changes.py
@@ -4,12 +4,11 @@ import datetime
 from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
-from django.db.utils import DatabaseError
 
 def ignore_exists(fun, *args, **kwargs):
     try:
         fun(*args, **kwargs)
-    except DatabaseError, exc:
+    except Exception, exc:
         if "exists" in str(exc):
             # don't panic, everything is ok: it's just a hack
             if db.has_ddl_transactions:


### PR DESCRIPTION
As mentioned in issue #149, the DatabaseError caught in the ignore_exists catch doesn't cover the error that MySQL raises (OperationalError). This patch catches any Exception, still checking for "exists" in the message 
