### PR TITLE
Always use UTC if CELERY_ENABLE_UTC=True.  Closes #131

### DIFF
--- a/djcelery/loaders.py
+++ b/djcelery/loaders.py
@@ -4,6 +4,8 @@ import imp
 import importlib
 import warnings
 
+from datetime import datetime
+
 from celery import signals
 from celery.loaders.base import BaseLoader
 from celery.datastructures import DictAttribute
@@ -35,8 +37,8 @@ class DjangoLoader(BaseLoader):
         # any embedded celerybeat process forks.
         signals.beat_embedded_init.connect(self.close_database)
 
-    def now(self, **kwargs):
-        return now()
+    def now(self, utc=False):
+        return datetime.utcnow() if utc else now()
 
     def read_configuration(self):
         """Load configuration from Django settings."""


### PR DESCRIPTION
This commit needs to be applied to the 2.5 branch to make django-celery 2.5.x compatible with celery 2.5.x.  Without it, we still get the #131 problem on the 2.5 branch.
