### PR TITLE
Replaced deprecated urls import.

### DIFF
--- a/djcelery/monproj/urls.py
+++ b/djcelery/monproj/urls.py
@@ -1,7 +1,11 @@
 from __future__ import absolute_import
 
-from django.conf.urls.defaults import (patterns, include, url,  # noqa
-                                       handler500, handler404)
+try:
+    from django.conf.urls import (patterns, include, url,
+                                  handler500, handler404)
+except ImportError:
+    from django.conf.urls.defaults import (patterns, include, url,  # noqa
+                                           handler500, handler404)
 from django.contrib import admin
 
 admin.autodiscover()

--- a/djcelery/urls.py
+++ b/djcelery/urls.py
@@ -13,7 +13,10 @@ URLs defined for celery.
 """
 from __future__ import absolute_import
 
-from django.conf.urls.defaults import patterns, url
+try:
+    from django.conf.urls import patterns, url
+except ImportError:
+    from django.conf.urls.defaults import patterns, url
 
 from . import views
 


### PR DESCRIPTION
`django.conf.urls.defaults` is deprecated as of django 1.4.

See release note https://docs.djangoproject.com/en/dev/releases/1.4/#django-conf-urls-defaults
