### PR TITLE
Oracle "not connected" not supported with the current check for "closed" in place

### DIFF
--- a/djcelery/loaders.py
+++ b/djcelery/loaders.py
@@ -68,7 +68,8 @@ class DjangoLoader(BaseLoader):
             try:
                 close()
             except DATABASE_ERRORS, exc:
-                if "closed" not in str(exc):
+                str_exc = str(exc)
+                if "closed" not in str_exc and "not connected" in str_exc:
                     raise
 
     def close_database(self, **kwargs):


### PR DESCRIPTION
Oracle error message looks like this:

```
OperationalError: ORA-03114: not connected to ORACLE
```

This should handle the Oracle case.  I'm in the process of testing the fix for our purposes at the moment.  I will update this pull request if that seems to fail or succeed.
