### PR TITLE
Logic error in _close_database() call ignoring already closed databases

### DIFF
--- a/djcelery/loaders.py
+++ b/djcelery/loaders.py
@@ -69,7 +69,7 @@ class DjangoLoader(BaseLoader):
                 close()
             except DATABASE_ERRORS, exc:
                 str_exc = str(exc)
-                if "closed" not in str_exc and "not connected" in str_exc:
+                if "closed" not in str_exc and "not connected" not in str_exc:
                     raise
 
     def close_database(self, **kwargs):


### PR DESCRIPTION
Forgot the `not` in there.  Otherwise the `raise` will only happen when "not connected" is in the string.
