### PR TITLE
USE_TZ=False leads to timezone database exceptions i celerycam

### DIFF
--- a/djcelery/snapshot.py
+++ b/djcelery/snapshot.py
@@ -59,7 +59,10 @@ class Camera(Polaroid):
             heartbeat = worker.heartbeats[-1]
         except IndexError:
             return
-        return aware_tstamp(heartbeat)
+        # Check for timezone settings
+        if getattr(settings, "USE_TZ", False):
+            return aware_tstamp(heartbeat)
+        return datetime.fromtimestamp(heartbeat)
 
     def handle_worker(self, (hostname, worker)):
         last_write, obj = self._last_worker_write[hostname]


### PR DESCRIPTION
The celery cam was giving errors when used with USE_TZ=False. This
fixes that. Tested on django 1.4 with all tests passing
