### PR TITLE
Alter test runner to store `TaskMeta`

### DIFF
--- a/djcelery/contrib/test_runner.py
+++ b/djcelery/contrib/test_runner.py
@@ -1,13 +1,10 @@
 from __future__ import absolute_import, unicode_literals
 
-from uuid import uuid4
-from datetime import datetime
-
 from django.conf import settings
 from django.test.simple import DjangoTestSuiteRunner
 
+from djcelery.backends.database import DatabaseBackend
 from celery.task import Task
-from djcelery.models import TaskState
 
 
 USAGE = """\
@@ -30,57 +27,26 @@ class CeleryTestSuiteRunner(DjangoTestSuiteRunner):
         settings.CELERY_ALWAYS_EAGER = True
         settings.CELERY_EAGER_PROPAGATES_EXCEPTIONS = True  # Issue #75
 
-
 class CeleryTestSuiteRunnerStoringResult(DjangoTestSuiteRunner):
-    """This custom test suite runner make some preliminary
-    monkey-patching allowing storing result of Celery task execution
-    in ``djcelery.models.TaskState`` model. Tasks run eagerly.
+    """Django test runner allowing testing of celery delayed tasks,
+    and storing the results of those tasks in ``TaskMeta``.
 
-    Exceptions is turned on. If you need to test ``on_failure``
-    behavior, you should monkey-patch in your test:
-        ``settings.CELERY_EAGER_PROPAGATES_EXCEPTIONS = False``
+    Requires setting CELERY_RESULT_BACKEND = 'database'.
 
-    USAGE:
-            In ``settings.py``:
-                TEST_RUNNER = 'djcelery.contrib.test_runner.' \
-                    'CeleryTestSuiteRunnerStoringResult'
+    To use this runner set ``settings.TEST_RUNNER``::
 
-            In ``tests.py``:
-                from djcelery.models import TaskState
-                TaskState.object.filter(state='SUCCESS', args__contains='test')
+        TEST_RUNNER = 'djcelery.contrib.test_runner.CeleryTestSuiteRunnerStoringResult'
 
     """
     def setup_test_environment(self, **kwargs):
-        """ Setting up test environment. """
-
         # Monkey-patch Task.on_success() method
         def on_success_patched(self, retval, task_id, args, kwargs):
-
-            TaskState.objects.create(task_id=uuid4().hex,
-                                     state='SUCCESS',
-                                     name=self.name,
-                                     result=retval,
-                                     args=args,
-                                     kwargs=kwargs,
-                                     tstamp=datetime.now())
+            DatabaseBackend().store_result(task_id, retval, "SUCCESS")
         Task.on_success = classmethod(on_success_patched)
 
-        # Monkey-patch Task.on_failure() method
-        def on_failure_patched(self, exc, task_id, args, kwargs, einfo):
-
-            TaskState.objects.create(task_id=uuid4().hex,
-                                     state='FAILURE',
-                                     name=self.name,
-                                     result=einfo,
-                                     args=args,
-                                     kwargs=kwargs,
-                                     tstamp=datetime.now())
-        Task.on_failure = classmethod(on_failure_patched)
-
-        # Call parent's version
         super(CeleryTestSuiteRunnerStoringResult,
-              self).setup_test_environment(**kwargs)
+                self).setup_test_environment(**kwargs)
 
-        # Tell celery run tasks synchronously
+        settings.CELERY_RESULT_BACKEND = 'database'
         settings.CELERY_ALWAYS_EAGER = True
         settings.CELERY_EAGER_PROPAGATES_EXCEPTIONS = True  # Issue #75


### PR DESCRIPTION
This patch changes `CeleryTestSuiteRunnerStoringResult` to store
`TaskMeta` results instead of `TaskState`.  In addition, it removes the
`on_failure` handling which could never have been invoked as implemented
anyway (as CELERY_EAGER_PROPAGATES_EXCEPTIONS was set True in the test
runner).

Addressing issue #191.
