### PR TITLE
Update djcelery/management/base.py

### DIFF
--- a/djcelery/management/base.py
+++ b/djcelery/management/base.py
@@ -58,7 +58,7 @@ class CeleryCommand(BaseCommand):
 
     def get_version(self):
         return 'celery {c.__version__}\ndjango-celery {d.__version__}'.format(
-                    celery, djcelery)
+                    c=celery, d=djcelery)
 
     def execute(self, *args, **options):
         broker = options.get('broker')


### PR DESCRIPTION
Format string method needs named parameters for it to work (or instead of c and d use positional parameters).
