### PR TITLE
See https://gist.github.com/4277730 for details

### DIFF
--- a/djcelery/utils.py
+++ b/djcelery/utils.py
@@ -48,15 +48,16 @@ try:
 
     def make_aware(value):
         if getattr(settings, 'USE_TZ', False):
-            # naive datetimes are assumed to be in UTC.
-            value = timezone.make_aware(value, timezone.utc)
+            if timezone.is_naive(value):
+                # naive datetimes are assumed to be in UTC.
+                value = timezone.make_aware(value, timezone.utc)
             # then convert to the Django configured timezone.
             default_tz = timezone.get_default_timezone()
             value = timezone.localtime(value, default_tz)
         return value
 
     def make_naive(value):
-        if getattr(settings, 'USE_TZ', False):
+        if getattr(settings, 'USE_TZ', False) and timezone.is_aware(value):
             default_tz = timezone.get_default_timezone()
             value = timezone.make_naive(value, default_tz)
         return value


### PR DESCRIPTION
Fix for Error in timer: ValueError('Not naive datetime (tzinfo is already set)',) in ./manage.py celerycam output. Raised on task.retry() (see environment settings and task example below).

However still receiving RuntimeWarning: DateTimeField received a naive datetime::

/home/user/.virtualenvs/storm/local/lib/python2.7/site-packages/django/db/models/fields/**init**.py:808: RuntimeWarning: DateTimeField received a naive datetime (2012-12-13 16:48:03) while time zone support is active.
  RuntimeWarning)

which I tend to postpone for now.
### requirements.txt

celery==3.0.12
Django==1.4.2
django-celery==3.0.11
librabbitmq==1.0.0
### settings.py

TIME_ZONE = 'UTC'
USE_I18N = True
USE_L10N = Trueform 
USE_TZ = True
BROKER_URL = 'librabbitmq://test:123456@localhost:5672/test'
import djcelery
djcelery.setup_loader()
### tasks.py

@celery.task()
def test_task():
    test_task.retry()
