### PR TITLE
Suppress model validation failures when using annotations

### DIFF
--- a/djcelery/management/commands/celery.py
+++ b/djcelery/management/commands/celery.py
@@ -11,7 +11,7 @@ base = celery.CeleryCommand(app=app)
 class Command(CeleryCommand):
     """The celery command."""
     help = 'celery commands, see celery help'
-    requires_model_validation = True
+    requires_model_validation = False
     options = (CeleryCommand.options
              + base.get_options()
              + base.preload_options)

--- a/djcelery/management/commands/celerybeat.py
+++ b/djcelery/management/commands/celerybeat.py
@@ -19,6 +19,6 @@ class Command(CeleryCommand):
              + beat.get_options()
              + beat.preload_options)
     help = 'Old alias to the "celery beat" command.'
-
+    requires_model_validation = False
     def handle(self, *args, **options):
         beat.run(*args, **options)

--- a/djcelery/management/commands/celerycam.py
+++ b/djcelery/management/commands/celerycam.py
@@ -19,7 +19,7 @@ class Command(CeleryCommand):
              + ev.get_options()
              + ev.preload_options)
     help = 'Takes snapshots of the clusters state to the database.'
-
+    requires_model_validation = False
     def handle(self, *args, **options):
         """Handle the management command."""
         options['camera'] = 'djcelery.snapshot.Camera'

--- a/djcelery/management/commands/celeryd.py
+++ b/djcelery/management/commands/celeryd.py
@@ -16,7 +16,7 @@ worker = worker.worker(app=app)
 class Command(CeleryCommand):
     """Run the celery daemon."""
     help = 'Old alias to the "celery worker" command.'
-    requires_model_validation = True
+    requires_model_validation = False
     options = (CeleryCommand.options
              + worker.get_options()
              + worker.preload_options)

--- a/djcelery/management/commands/celeryd_detach.py
+++ b/djcelery/management/commands/celeryd_detach.py
@@ -16,7 +16,7 @@ from djcelery.management.base import CeleryCommand
 class Command(CeleryCommand):
     """Run the celery daemon."""
     help = 'Runs a detached Celery worker node.'
-    requires_model_validation = True
+    requires_model_validation = False
     options = celeryd_detach.OPTION_LIST
 
     def run_from_argv(self, argv):

--- a/djcelery/management/commands/celeryd_multi.py
+++ b/djcelery/management/commands/celeryd_multi.py
@@ -14,7 +14,7 @@ class Command(CeleryCommand):
     """Run the celery daemon."""
     args = '[name1, [name2, [...]> [worker options]'
     help = 'Manage multiple Celery worker nodes.'
-    requires_model_validation = True
+    requires_model_validation = False
     options = ()
     keep_base_opts = True
 

--- a/djcelery/management/commands/celerymon.py
+++ b/djcelery/management/commands/celerymon.py
@@ -33,7 +33,7 @@ class Command(CeleryCommand):
     options = (CeleryCommand.options
                + (mon and mon.get_options() + mon.preload_options or ()))
     help = 'Run the celery monitor'
-
+    requires_model_validation = False
     def handle(self, *args, **options):
         """Handle the management command."""
         if mon is None:

--- a/djcelery/management/commands/djcelerymon.py
+++ b/djcelery/management/commands/djcelerymon.py
@@ -38,7 +38,7 @@ class Command(CeleryCommand):
     help = 'Starts Django Admin instance and celerycam in the same process.'
     # see http://code.djangoproject.com/changeset/13319.
     stdout, stderr = sys.stdout, sys.stderr
-
+    requires_model_validation = False
     def handle(self, addrport="", *args, **options):
         """Handle the management command."""
         server = WebserverThread(addrport, *args, **options)


### PR DESCRIPTION
Suppress model validation due to this Django bug https://code.djangoproject.com/ticket/19126.

The assumption is that model validation should be happening in other parts of the application.

Issue #224