### PR TITLE
Log rather than raise ValueError in ModelEntry

### DIFF
--- a/djcelery/schedulers.py
+++ b/djcelery/schedulers.py
@@ -43,11 +43,12 @@ class ModelEntry(ScheduleEntry):
             self.args = loads(model.args or '[]')
             self.kwargs = loads(model.kwargs or '{}')
         except ValueError:
-            # disable because of error deserializing args/kwargs
+            logging.exception(exc)
+            logging.error('Failed to serialize arguments for %s.', self.name)
+            logging.warning('Disabling %s', self.name)
             model.no_changes = True
             model.enabled = False
             model.save()
-            raise
 
         self.options = {'queue': model.queue,
                         'exchange': model.exchange,


### PR DESCRIPTION
When using the Django admin site to add periodic tasks, my tasks kept being reset to "Disabled".
No logs were showing any errors, so I started digging through the code.
It took me a little while to find that in the ModelEntry class' **init** method, errors are suppressed whenever "args" or "kwargs" failed to deserialize.
It'd be nice for future users / developers to not have to hunt down this problem in future releases.

Here's what happened in my case:
-  Make a new Periodic Task in the Django admin site.
-  Set "args" = [135L, 348L, 400L](which is pickleable, but not JSON serializable).
-  Hit save.
-  Start up celery beat, instructing it to use djcelery.schedulers.DatabaseScheduler
-  DatabaseScheduler does "self.all_as_schedule()" when the schedule property is accessed (line 239).
-  All_as_schedule gets all "enabled" periodic tasks from the DB, makes a ModelEntry out of each one, and attaches it to a dictionary (note that ValueError is explicitly ignored):

``` python
    for model in self.Model.objects.enabled():
        try:
            s[model.name] = self.Entry(model)
        except ValueError:
            pass
```
- Within Entry (a pointer to schedulers.ModelEntry), **init** does this:

``` python
    try:
        self.args = deserialize(model.args or u"[]")
        self.kwargs = deserialize(model.kwargs or u"{}")
    except ValueError:
        # disable because of error deserializing args/kwargs
        model.no_changes = True
        model.enabled = False
        model.save()
        raise
```
- ModelEntry tries to deserialize "model.args", fails, disables the scheduled process, and raises ValueError
- All_as_schedule catches ValueError and silently passes
