### PR TITLE
Fix now() when USE_TZ is turned off in Django 1.5

### DIFF
--- a/djcelery/utils.py
+++ b/djcelery/utils.py
@@ -62,7 +62,10 @@ try:
         return value
 
     def now():
-        return timezone.localtime(timezone.now())
+        if getattr(settings, 'USE_TZ', False):
+            return timezone.localtime(timezone.now())
+        else:
+            return timezone.now()
 
 except ImportError:
     now = datetime.now


### PR DESCRIPTION
Django 1.5 changes the contract of timezone.localtime (which was
previously undocumented) such that it must be provided with a timezone
aware datetime object. timezone.now() only returns a timezone aware
object when USE_TZ is enabled, so when USE_TZ is not set it is not
safe to call timezone.localtime() on the result.
