### PR TITLE
Fix for django 1.5 with Python 3 error for string handling with force_unicode.

### DIFF
--- a/djcelery/admin.py
+++ b/djcelery/admin.py
@@ -173,7 +173,7 @@ class TaskMonitor(ModelMonitor):
         context = {
             'title': _('Rate limit selection'),
             'queryset': queryset,
-            'object_name': force_str(opts.verbose_name),
+            'object_name': force_text(opts.verbose_name),
             'action_checkbox_name': helpers.ACTION_CHECKBOX_NAME,
             'opts': opts,
             'app_label': app_label,

--- a/djcelery/picklefield.py
+++ b/djcelery/picklefield.py
@@ -80,7 +80,7 @@ class PickledObjectField(models.Field):
 
     def get_db_prep_value(self, value, **kwargs):
         if value is not None and not isinstance(value, PickledObject):
-            return force_str(encode(value, self.compress, self.protocol))
+            return force_text(encode(value, self.compress, self.protocol))
         return value
 
     def value_to_string(self, obj):


### PR DESCRIPTION
The django 1.5 porting guide indicates that force_unicode will no longer work for python 3. To keep python 2 compatibility a try clause was placed to keep the string handling looking for force_unicode.

Thanks
