### PR TITLE
Handle removal of CacheClass

### DIFF
--- a/djcelery/backends/cache.py
+++ b/djcelery/backends/cache.py
@@ -40,7 +40,7 @@ class DjangoMemcacheWrapper(object):
 from django.core.cache.backends.base import InvalidCacheBackendError
 try:
     from django.core.cache.backends.memcached import CacheClass
-except InvalidCacheBackendError:
+except (ImportError, InvalidCacheBackendError):
     pass
 else:
     if django.VERSION[0:2] < (1, 2) and isinstance(cache, CacheClass):


### PR DESCRIPTION
Django removed django.core.cache.backends.memcached.CacheClass
https://github.com/django/django/commit/59351247bd635c55bb72a156d71f0d3a27563a67

When using memcache as the cache backend, I have to catch ImportError to make djcelery work with the Django development version (parentheses around this tuple are used to catch both).
