### PR TITLE
If the value is not a native datetime, we don't need to make_aware

### DIFF
--- a/djcelery/utils.py
+++ b/djcelery/utils.py
@@ -49,7 +49,8 @@ try:
     def make_aware(value):
         if getattr(settings, 'USE_TZ', False):
             # naive datetimes are assumed to be in UTC.
-            value = timezone.make_aware(value, timezone.utc)
+            if timezone.is_naive(value):
+                value = timezone.make_aware(value, timezone.utc)
             # then convert to the Django configured timezone.
             default_tz = timezone.get_default_timezone()
             value = timezone.localtime(value, default_tz)


### PR DESCRIPTION
as title.
