### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -179,7 +179,7 @@ setup(
     data_files=data_files,
     zip_safe=False,
     install_requires=[
-        'pytz==2013b',
+        'pytz>=2013b',
         'celery>=3.0.11',
     ],
     cmdclass={'test': RunTests,


### PR DESCRIPTION
new version of pip breaks without explicit versions for pytz
