### PR TITLE
Fixing extra_context issue in ModelMonitor.change_view

### DIFF
--- a/djcelery/admin.py
+++ b/djcelery/admin.py
@@ -92,7 +92,7 @@ class ModelMonitor(admin.ModelAdmin):
         extra_context = extra_context or {}
         extra_context.setdefault('title', self.detail_title)
         return super(ModelMonitor, self).change_view(request, object_id,
-                                                     extra_context)
+                                                     extra_context=extra_context)
 
     def has_delete_permission(self, request, obj=None):
         if not self.can_delete:


### PR DESCRIPTION
django.contrib.admin.options.py:ModelAdmin.change_view has following signature(Django 1.4&1.5):

def change_view(self, request, object_id, form_url='', extra_context=None):

Currently passing extra_context dict without explicit naming( extra_context=extra_context) actually works as implicit form_url=extra_context. This issue blocks submiting Worker and Task admin forms.
