### PR TITLE
Add djcelery.schedulers.DatabaseScheduler judgment custom class

### DIFF
--- a/djcelery/admin.py
+++ b/djcelery/admin.py
@@ -21,6 +21,7 @@ from .models import (
     PeriodicTask, IntervalSchedule, CrontabSchedule,
 )
 from .humanize import naturaldate
+from .utils import check_scheduler
 
 try:
     from django.utils.encoding import force_text
@@ -293,8 +294,7 @@ class PeriodicTaskAdmin(admin.ModelAdmin):
     def changelist_view(self, request, extra_context=None):
         extra_context = extra_context or {}
         scheduler = getattr(settings, 'CELERYBEAT_SCHEDULER', None)
-        if scheduler != 'djcelery.schedulers.DatabaseScheduler':
-            extra_context['wrong_scheduler'] = True
+        extra_context['wrong_scheduler'] = check_scheduler(scheduler)
         return super(PeriodicTaskAdmin, self).changelist_view(request,
                                                               extra_context)
 

--- a/djcelery/utils.py
+++ b/djcelery/utils.py
@@ -74,3 +74,16 @@ def maybe_make_aware(value):
     if value:
         return make_aware(value)
     return value
+
+def check_scheduler(scheduler):
+    if scheduler == 'djcelery.schedulers.DatabaseScheduler':
+        return False
+    else:
+        i = scheduler.rfind('.')
+        class_name = scheduler[i+1:]
+        from djcelery.schedulers import DatabaseScheduler
+        try:
+            module =  __import__(scheduler[:i])
+            return not issubclass(getattr(module, class_name), DatabaseScheduler)
+        except (AttributeError, ImportError):
+            return True


### PR DESCRIPTION
In my project, because of many reasons to use one django orm storage all djcelery_periodictask. But there are several beat distributed on different servers, Cause the business needs, I inherited djcelery.schedulers.DatabaseScheduler class customized some implementations, but djcelery template I have not prompted to use the correct DatabaseScheduler module,

I looked under the code because it simply verifies whether settings.py set CELERYBEAT_SCHEDULER is 'djcelery.schedulers.DatabaseScheduler', rather than to verify whether the specified configuration inherited from djcelery.schedulers.DatabaseScheduler
