### PR TITLE
JSON Validation on PeriodicTaskForm

### DIFF
--- a/djcelery/admin.py
+++ b/djcelery/admin.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
+from anyjson import loads
+
 from django import forms
 from django.conf import settings
 from django.contrib import admin
@@ -259,6 +261,20 @@ def periodic_task_form():
                 self._errors['task'] = self.error_class(exc.messages)
                 raise exc
             return data
+
+        def _clean_json(self, field):
+            value = self.cleaned_data[field]
+            try:
+                loads(value)
+            except ValueError, exc:
+                raise forms.ValidationError(_('Unable to parse JSON: %s') % exc)
+            return value
+
+        def clean_args(self):
+            return self._clean_json('args')
+
+        def clean_kwargs(self):
+            return self._clean_json('kwargs')
 
     return PeriodicTaskForm
 


### PR DESCRIPTION
I dont think that django-celery should let you save a periodic task with args/kwargs that are invalid JSON. Currently the app will let you save whatever you want as args/kwargs and then will blow up in the background when trying to run the task.

This patch checks that the args/kwargs you submit are valid JSON when you save the form and before the task is run. Notice this patch does not modify the args/kwargs but just validates that they are wellformed JSON.
