### PR TITLE
Fix bug in celerycam about "MySQL backend does not support timezone-aware datetimes." when a celery task has defined expires option

### DIFF
--- a/djcelery/models.py
+++ b/djcelery/models.py
@@ -348,7 +348,7 @@ class TaskState(models.Model):
 
     def save(self, *args, **kwargs):
         self.expires = (None if self.expires is None
-                        else datetime.utcfromtimestamp(mktime(self.expires.timetuple())))))))
+                        else datetime.utcfromtimestamp(float("%d.%s" % (mktime(self.expires.timetuple()), self.expires.microsecond))))
         super(TaskState, self).save(*args, **kwargs)
 
     def __unicode__(self):


### PR DESCRIPTION
Fix bug in celerycam about "MySQL backend does not support timezone-aware datetimes." when a celery task has defined expires option
