### PR TITLE
Updated django-celery scheduler to import multiprocessing.utils.Finalize

### DIFF
--- a/djcelery/schedulers.py
+++ b/djcelery/schedulers.py
@@ -10,7 +10,13 @@ from celery import schedules
 from celery.beat import Scheduler, ScheduleEntry
 from celery.utils.encoding import safe_str, safe_repr
 from celery.utils.timeutils import is_naive
-from multiprocessing.util import Finalize
+
+try:
+    # The finalize module was removed from Kombu in version 3.0.
+    # Fall back to kombu.utils.finalize if Kombu version < 3.x
+    from multiprocessing.util import Finalize
+except ImportError:
+    from kombu.utils.finalize import Finalize
 
 from django.db import transaction
 from django.core.exceptions import ObjectDoesNotExist


### PR DESCRIPTION
kombu.utils.Finalize was removed in kombu 3.0. The use  of multiprocessing.util.Finalize is recommended instead.

This file raises an exception when trying to start celery beat.
