### PR TITLE
Recover django import patterns, url ImportError

### DIFF
--- a/djcelery/monproj/urls.py
+++ b/djcelery/monproj/urls.py
@@ -4,7 +4,7 @@ try:
     from django.conf.urls import (patterns, include, url,
                                   handler500, handler404)
 except ImportError:
-    from django.conf.urls import (patterns, include, url,  # noqa
+    from django.conf.urls.defaults import (patterns, include, url,  # noqa
                                   handler500, handler404)
 from django.contrib import admin
 

--- a/djcelery/urls.py
+++ b/djcelery/urls.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import, unicode_literals
 try:
     from django.conf.urls import patterns, url
 except ImportError:  # deprecated since Django 1.4
-    from django.conf.urls import patterns, url  # noqa
+    from django.conf.urls.defaults import patterns, url  # noqa
 
 from . import views
 


### PR DESCRIPTION
Recently,  This has support for django 1.6. but i see this:

```
try:
    from django.conf.urls import patterns, url
except ImportError:  # deprecated since Django 1.4
    from django.conf.urls import patterns, url  # noqa
```

I do not quite understand, and I now use django is 1.2.5, I must use the past:

```
from django.conf.urls.defaults import patterns, url
```
