### PR TITLE
Potential fix for issue celery/django-celery#289: use manual tranaction mgmt

### DIFF
--- a/djcelery/snapshot.py
+++ b/djcelery/snapshot.py
@@ -129,8 +129,9 @@ class Camera(Polaroid):
 
         return obj
 
+    @transaction.commit_manually
     def on_shutter(self, state, commit_every=100):
-        if not state.event_count:
+        if not state.event_count and transaction.is_dirty():
             transaction.commit()
             return
 
@@ -143,6 +144,8 @@ class Camera(Polaroid):
         for worker in state.workers.items():
             self.handle_worker(worker)
         _handle_tasks()
+        if transaction.is_dirty():
+            transaction.commit()
 
     def on_cleanup(self):
         expired = (self.TaskState.objects.expire_by_states(states, expires)


### PR DESCRIPTION
I see issue celery/django-celery#289 when using the latest release of djcelery and celery with Django 1.4. Perhaps this issue is due to the new autocommit default in Django 1.6?

I assume the intent of the commit calls in on_snapshot() i, to improve performance by committing every N updates rather than for each one. I added the commit_manually decorator to the on_snapshot() method, which (I think) should leave the transaction open until an explicit commit. I always make sure we commit before leaving on_snapshot() if the transaction status is dirty. This keeps commit_manually happy and is probably a good idea anyway.
