### PR TITLE
Do not pass *args to celery.bin.worker.run.

### DIFF
--- a/djcelery/management/commands/celeryd.py
+++ b/djcelery/management/commands/celeryd.py
@@ -22,4 +22,5 @@ class Command(CeleryCommand):
                + worker.preload_options)
 
     def handle(self, *args, **options):
+        worker.check_args(args)
         worker.run(**options)


### PR DESCRIPTION
The method celery.bin.worker.run only takes keyword arguments. Passing
*args to it was resulting in the exception:

TypeError: run() got multiple values for keyword argument 'hostname'
