### PR TITLE
Fix snapshot.aware_tstamp by converting from utc timestamp

### DIFF
--- a/djcelery/snapshot.py
+++ b/djcelery/snapshot.py
@@ -33,7 +33,7 @@ debug = logger.debug
 
 def aware_tstamp(secs):
     """Event timestamps uses the local timezone."""
-    return maybe_make_aware(datetime.fromtimestamp(secs))
+    return maybe_make_aware(datetime.utcfromtimestamp(secs))
 
 
 class Camera(Polaroid):


### PR DESCRIPTION
Since the timestamps are generated using time.time, which should be in utc we have to use utcfromtimestamp to get the correct datetime object.
