### PR TITLE
Adding mongodb database errors

### DIFF
--- a/djcelery/utils.py
+++ b/djcelery/utils.py
@@ -36,12 +36,19 @@ try:
                                oracle.OperationalError)
 except ImportError:
     _oracle_database_errors = ()  # noqa
+try:
+    import pymongo as mongodb
+    _mongodb_database_errors = (mongodb.errors.AutoReconnect,
+                                mongodb.errors.OperationFailure)
+except ImportError:
+    _mongodb_database_errors = ()  # noqa
 
 DATABASE_ERRORS = ((DatabaseError, ) +
                    _my_database_errors +
                    _pg_database_errors +
                    _lite_database_errors +
-                   _oracle_database_errors)
+                   _oracle_database_errors +
+                   _mongodb_database_errors)
 
 
 try:


### PR DESCRIPTION
In order to make djcelery supports Mongodb for the cases when Django uses this backend, the exceptions must be handled so this pull request adds Mongodb exceptions to the DATABASE_ERRORS tuple as well as it is already doing for MySql, Oracle, PostGreSQL or Sqlite3.
