### PR TITLE
Update base.py

### DIFF
--- a/djcelery/management/base.py
+++ b/djcelery/management/base.py
@@ -55,7 +55,7 @@ patch_thread_ident()
 
 class CeleryCommand(BaseCommand):
     options = BaseCommand.option_list
-    skip_opts = ['--app', '--loader', '--config']
+    skip_opts = ['--app', '--loader', '--config', '--no-color']
     keep_base_opts = False
 
     def get_version(self):


### PR DESCRIPTION
option --no-color conflicts with django option --no-color in django1.7b1
