### PR TITLE
Add a stderr and stdout to the Celery commands

### DIFF
--- a/djcelery/management/base.py
+++ b/djcelery/management/base.py
@@ -57,6 +57,7 @@ class CeleryCommand(BaseCommand):
     options = BaseCommand.option_list
     skip_opts = ['--app', '--loader', '--config']
     keep_base_opts = False
+    stdout, stderr = sys.stdout, sys.stderr
 
     def get_version(self):
         return 'celery {c.__version__}\ndjango-celery {d.__version__}'.format(


### PR DESCRIPTION
The management commands are broken with Django 1.7, which complains because the Command has no std[out|err] attribute.
