### PR TITLE
Fix AppRegistryNotReady exception when Celery beat uses DatabaseSchedule...

### DIFF
--- a/djcelery/schedulers.py
+++ b/djcelery/schedulers.py
@@ -12,6 +12,7 @@ from celery.utils.encoding import safe_str, safe_repr
 from celery.utils.log import get_logger
 from celery.utils.timeutils import is_naive
 
+import django
 from django.db import transaction
 from django.core.exceptions import ObjectDoesNotExist
 
@@ -154,6 +155,9 @@ class DatabaseScheduler(Scheduler):
             DEFAULT_MAX_INTERVAL)
 
     def setup_schedule(self):
+        if hasattr(django, 'setup'):
+            # For Django 1.7+
+            django.setup()
         self.install_default_entries(self.schedule)
         self.update_from_dict(self.app.conf.CELERYBEAT_SCHEDULE)
 


### PR DESCRIPTION
...r with Django 1.7.

The application registry feature is introduced in Django 1.7. The `DatabaseScheduler` try to access Django application models before the application registry is populated. As a result, `AppRegistryNotReady` exception is raised when we run `celery -A proj beat -S djcelery.schedulers.DatabaseScheduler`.

 This PR try to fix this problem by running `django.setup()` in `DatabaseScheduler.setup_schedule()`.

https://docs.djangoproject.com/en/dev/releases/1.7/#standalone-scripts
