### PR TITLE
Fix slow start time

### DIFF
--- a/djcelery/management/commands/celery.py
+++ b/djcelery/management/commands/celery.py
@@ -11,11 +11,14 @@ base = celery.CeleryCommand(app=app)
 class Command(CeleryCommand):
     """The celery command."""
     help = 'celery commands, see celery help'
+    requires_model_validation = False
     options = (CeleryCommand.options
                + base.get_options()
                + base.preload_options)
 
     def run_from_argv(self, argv):
+        if argv[2] == 'worker':
+            self.requires_model_validation = True
         argv = self.handle_default_options(argv)
         if self.requires_model_validation:
             self.validate()


### PR DESCRIPTION
Model validation is only needed when starting a worker, status, multi, etc. shouldn't need this, and full validation can be really slow, depending on the django project.
