### PR TITLE
Fix DatabaseScheduler behavior when schedule is changed from interval to crontab

### DIFF
--- a/djcelery/schedulers.py
+++ b/djcelery/schedulers.py
@@ -120,6 +120,11 @@ class ModelEntry(ScheduleEntry):
             fields.pop(skip_field, None)
         schedule = fields.pop('schedule')
         model_schedule, model_field = cls.to_model_schedule(schedule)
+
+        # reset schedule
+        for t in cls.model_schedules:
+            fields[t[2]] = None
+
         fields[model_field] = model_schedule
         fields['args'] = dumps(fields.get('args') or [])
         fields['kwargs'] = dumps(fields.get('kwargs') or {})
@@ -131,7 +136,7 @@ class ModelEntry(ScheduleEntry):
         ))
 
     def __repr__(self):
-        return '<ModelEntry: {0} {1}(*{2}, **{3}) {{4}}>'.format(
+        return '<ModelEntry: {0} {1}(*{2}, **{3}) {4}>'.format(
             safe_str(self.name), self.task, safe_repr(self.args),
             safe_repr(self.kwargs), self.schedule,
         )

--- a/djcelery/tests/test_schedulers.py
+++ b/djcelery/tests/test_schedulers.py
@@ -99,6 +99,21 @@ class test_ModelEntry(unittest.TestCase):
         self.assertGreater(e3.last_run_at, e2.last_run_at)
         self.assertEqual(e3.total_run_count, 1)
 
+    def test_from_entry(self):
+        name = 'interval-vs-crontab'
+        entry = {'task': 'djcelery.unittest.add{0}'.format(_next_id()),
+                 'args': '[2, 2]',
+                 'schedule': timedelta(hours=24),}
+        self.Entry.from_entry(name, **entry)
+        schedule1 = PeriodicTask.objects.get(name=name).schedule
+        self.assertIsInstance(schedule1, schedule)
+
+        # update schedule
+        entry['schedule'] = crontab(minute=0, hour='*/6')
+        self.Entry.from_entry(name, **entry)
+        schedule2 = PeriodicTask.objects.get(name=name).schedule
+        self.assertIsInstance(schedule2, crontab)
+
 
 class test_DatabaseScheduler(unittest.TestCase):
     Scheduler = TrackingScheduler
@@ -142,8 +157,6 @@ class test_DatabaseScheduler(unittest.TestCase):
 
         self.m1.args = '[32, 32]'
         self.m1.save()
-        e1 = self.s.schedule[self.m1.name]
-        self.assertListEqual(e1.args, [32, 32])
         e1 = self.s.schedule[self.m1.name]
         self.assertListEqual(e1.args, [32, 32])
 


### PR DESCRIPTION
`ModelEntry` was not checking if there is `interval` value in DB when updating scheduled task from settings dict.
The result was unexpected (and frustrating) behavior when one decides that he need more fine grained control over execution schedule and change only `schedule` from `timedelta` to `crontab`.

I propose to set schedule fields to `None` prior setting a proper value.
