### PR TITLE
DatabaseScheduler: Reload config when Cron or Interval was changed

### DIFF
--- a/djcelery/models.py
+++ b/djcelery/models.py
@@ -141,6 +141,8 @@ class CrontabSchedule(models.Model):
         _('month of year'), max_length=64, default='*',
     )
 
+    no_changes = False
+
     class Meta:
         verbose_name = _('crontab')
         verbose_name_plural = _('crontabs')
@@ -181,6 +183,8 @@ class CrontabSchedule(models.Model):
 class PeriodicTasks(models.Model):
     ident = models.SmallIntegerField(default=1, primary_key=True, unique=True)
     last_update = models.DateTimeField(null=False)
+
+    no_changes = False
 
     objects = managers.ExtendedManager()
 
@@ -289,6 +293,11 @@ class PeriodicTask(models.Model):
 signals.pre_delete.connect(PeriodicTasks.changed, sender=PeriodicTask)
 signals.pre_save.connect(PeriodicTasks.changed, sender=PeriodicTask)
 
+signals.pre_delete.connect(PeriodicTasks.changed, sender=IntervalSchedule)
+signals.pre_save.connect(PeriodicTasks.changed, sender=IntervalSchedule)
+
+signals.pre_delete.connect(PeriodicTasks.changed, sender=CrontabSchedule)
+signals.pre_save.connect(PeriodicTasks.changed, sender=CrontabSchedule)
 
 class WorkerState(models.Model):
     hostname = models.CharField(_('hostname'), max_length=255, unique=True)


### PR DESCRIPTION
Using the same signal when PeriodicTask was changed on Django ORM
