### PR TITLE
Made use of CELERY_ENABLE_UTC

### DIFF
--- a/djcelery/models.py
+++ b/djcelery/models.py
@@ -15,7 +15,7 @@ from celery.events.state import heartbeat_expires
 
 from . import managers
 from .picklefield import PickledObjectField
-from .utils import now
+from .utils import fromtimestamp, now
 from .compat import python_2_unicode_compatible
 
 TASK_STATE_CHOICES = zip(states.ALL_STATES, states.ALL_STATES)
@@ -359,11 +359,11 @@ class TaskState(models.Model):
 
     def save(self, *args, **kwargs):
         if self.eta is not None:
-            self.eta = datetime.utcfromtimestamp(float('%d.%s' % (
+            self.eta = fromtimestamp(float('%d.%s' % (
                 mktime(self.eta.timetuple()), self.eta.microsecond,
             )))
         if self.expires is not None:
-            self.expires = datetime.utcfromtimestamp(float('%d.%s' % (
+            self.expires = fromtimestamp(float('%d.%s' % (
                 mktime(self.expires.timetuple()), self.expires.microsecond,
             )))
         super(TaskState, self).save(*args, **kwargs)

--- a/djcelery/snapshot.py
+++ b/djcelery/snapshot.py
@@ -13,7 +13,7 @@ from celery.utils.log import get_logger
 from celery.utils.timeutils import maybe_iso8601
 
 from .models import WorkerState, TaskState
-from .utils import maybe_make_aware
+from .utils import fromtimestamp, maybe_make_aware
 
 WORKER_UPDATE_FREQ = 60  # limit worker timestamp write freq.
 SUCCESS_STATES = frozenset([states.SUCCESS])
@@ -33,7 +33,7 @@ debug = logger.debug
 
 def aware_tstamp(secs):
     """Event timestamps uses the local timezone."""
-    return maybe_make_aware(datetime.utcfromtimestamp(secs))
+    return maybe_make_aware(fromtimestamp(secs))
 
 
 class Camera(Polaroid):

--- a/djcelery/utils.py
+++ b/djcelery/utils.py
@@ -93,3 +93,10 @@ def is_database_scheduler(scheduler):
     from kombu.utils import symbol_by_name
     from .schedulers import DatabaseScheduler
     return issubclass(symbol_by_name(scheduler), DatabaseScheduler)
+
+
+def fromtimestamp(value):
+    if getattr(settings, 'CELERY_ENABLE_UTC', False):
+        return datetime.utcfromtimestamp(value)
+    else:
+        return datetime.fromtimestamp(value)


### PR DESCRIPTION
Hi!

I work for one company and in our project we use Django 1.6 with: 
*USE_TZ = False*
*TIME_ZONE = 'US/Pacific'*

Celery has following settings:
*CELERY_ENABLE_UTC = False*
*CELERY_TIMEZONE = TIME_ZONE*

The problem was that djcelery admin interface showed UTC time instead of *US/Pacific* as we wanted. I've found out that djcelery didn't make use of *CELERY_ENABLE_UTC* parameter, so I've added the support for this.

I believe that some of open issues might be connected: #192, #324, #292 