### PR TITLE
prevent redundant migrations for py3 and #399

### DIFF
--- a/djcelery/models.py
+++ b/djcelery/models.py
@@ -19,7 +19,7 @@ from .utils import fromtimestamp, now
 from .compat import python_2_unicode_compatible
 
 ALL_STATES = sorted(states.ALL_STATES)
-TASK_STATE_CHOICES = zip(ALL_STATES, ALL_STATES)
+TASK_STATE_CHOICES = sorted(zip(ALL_STATES, ALL_STATES))
 
 
 @python_2_unicode_compatible


### PR DESCRIPTION
Fixes #399 

Hello, django-celery constantly trying to create new migration each time.
```python
operations = [
    migrations.AlterField(
        model_name='taskmeta',
        name='status',
        field=models.CharField(
            default='PENDING', 
            choices=[
                ('SUCCESS', 'SUCCESS'), 
                ('RETRY', 'RETRY'), 
                ('STARTED', 'STARTED'), 
                ('REVOKED', 'REVOKED'), 
                ('RECEIVED', 'RECEIVED'), 
                ('PENDING', 'PENDING'), 
                ('FAILURE', 'FAILURE')
            ], 
            max_length=50, 
            verbose_name='state'
        ),
    ),
]
```

```python
operations = [
    migrations.AlterField(
        model_name='taskmeta',
        name='status',
        field=models.CharField(
            choices=[
                ('RETRY', 'RETRY'), 
                ('RECEIVED', 'RECEIVED'), 
                ('PENDING', 'PENDING'), 
                ('FAILURE', 'FAILURE'), 
                ('SUCCESS', 'SUCCESS'), 
                ('REVOKED', 'REVOKED'), 
                ('STARTED', 'STARTED')
            ], 
            verbose_name='state', 
            max_length=50, 
            default='PENDING'
        ),
    ),
]
```

```python
operations = [
    migrations.AlterField(
        model_name='taskmeta',
        name='status',
        field=models.CharField(
            max_length=50, 
            choices=[
                ('SUCCESS', 'SUCCESS'), 
                ('FAILURE', 'FAILURE'), 
                ('RETRY', 'RETRY'), 
                ('REVOKED', 'REVOKED'), 
                ('STARTED', 'STARTED'), 
                ('RECEIVED', 'RECEIVED'), 
                ('PENDING', 'PENDING')
            ], 
            default='PENDING', 
            verbose_name='state'
        ),
    ),
]
```
And so on...