### PR TITLE
updated docs about migrating celery in Django

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -92,21 +92,22 @@ To install using ``easy_install``,::
 
     $ easy_install django-celery
 
-You will then want to create the necessary tables. If you are using south_
-for schema migrations, you'll want to::
+You will then want to create the necessary tables. If you're using Django 1.7+
+or an older version with south_, you'll want to::
 
     $ python manage.py migrate djcelery
 
 For Django 1.6 and older
 ------------------------
 
-For those who are not using south, a normal :command:`syncdb` will work::
+For older versions of Django without south_, a normal :command:`syncdb` will
+work::
 
     $ python manage.py syncdb
 
 .. _south: http://pypi.python.org/pypi/South/
 
-For Django 1.7 and newer
+For South users
 ------------------------
 
 If you are still using South, you should either:


### PR DESCRIPTION
South is deprecated because Django has migrations native now