### PR TITLE
Django 1.10 incompatibility: model instance has no _default_manager attribute

### DIFF
--- a/djcelery/schedulers.py
+++ b/djcelery/schedulers.py
@@ -95,7 +95,7 @@ class ModelEntry(ScheduleEntry):
     def save(self):
         # Object may not be synchronized, so only
         # change the fields we care about.
-        obj = self.model._default_manager.get(pk=self.model.pk)
+        obj = type(self.model)._default_manager.get(pk=self.model.pk)
         for field in self.save_fields:
             setattr(obj, field, getattr(self.model, field))
         obj.last_run_at = make_aware(obj.last_run_at)


### PR DESCRIPTION
It appears that Django 1.10 removes the `_default_manager` attribute from model instances (per: https://code.djangoproject.com/ticket/26652).  django-celery currently uses this attribute in the `ModelEntry` class in schedulers.py (https://github.com/celery/django-celery/blob/bac46064cf19f6de026a3ed30b54569fb1aa325e/djcelery/schedulers.py#L98).  As a result, using django-celery with Django 1.10 results in errors like this:

```
[2016-06-25 20:14:42,098: ERROR/Beat] Process Beat
Traceback (most recent call last):
  File "/Users/mfenniak/.virtualenvs/iohint-background/lib/python3.5/site-packages/billiard/process.py", line 292, in _bootstrap
    self.run()
  File "/Users/mfenniak/.virtualenvs/iohint-background/lib/python3.5/site-packages/celery/beat.py", line 553, in run
    self.service.start(embedded_process=True)
  File "/Users/mfenniak/.virtualenvs/iohint-background/lib/python3.5/site-packages/celery/beat.py", line 486, in start
    self.scheduler._do_sync()
  File "/Users/mfenniak/.virtualenvs/iohint-background/lib/python3.5/site-packages/celery/beat.py", line 276, in _do_sync
    self.sync()
  File "/Users/mfenniak/.virtualenvs/iohint-background/lib/python3.5/site-packages/djcelery/schedulers.py", line 209, in sync
    self.schedule[name].save()
  File "/Users/mfenniak/.virtualenvs/iohint-background/lib/python3.5/site-packages/djcelery/schedulers.py", line 98, in save
    obj = self.model._default_manager.get(pk=self.model.pk)
AttributeError: 'PeriodicTask' object has no attribute '_default_manager'
```

This PR fixes the issue by accessing _default_manager on the model type, rather than the model instance.