### PR TITLE
Fix tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
     -r{toxinidir}/requirements/test.txt
     1.7: Django>=1.7.0,<1.8.0
     1.8: Django>=1.8.0,<1.9.0
-    1.8: Django>=1.9.0,<1.10.0
+    1.9: Django>=1.9.0,<1.10.0
 
 setenv =
     PYTHONPATH={toxinidir}/tests


### PR DESCRIPTION
This fixes testing with tox on django 1.8 and 1.9.