### PR TITLE
Allow using custom Camera

### DIFF
--- a/djcelery/management/commands/celerycam.py
+++ b/djcelery/management/commands/celerycam.py
@@ -22,5 +22,5 @@ class Command(CeleryCommand):
 
     def handle(self, *args, **options):
         """Handle the management command."""
-        options['camera'] = 'djcelery.snapshot.Camera'
+        options['camera'] = options.get('camera', 'djcelery.snapshot.Camera')
         ev.run(*args, **options)


### PR DESCRIPTION
**Problem**

I would like to use a custom `Camera` class to do some custom logic. Currently I'm not able to override the default one on the command line, because the parameter is always reset to `djcelery.snapshot.Camera`.

**Solution**

Allow to use a custom camera by using the `-c` or `--camera` parameter. Fallback to default if not passed.
