### PR TITLE
Only run flake8 against djcelery package

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,4 +21,4 @@ basepython = python2.7
 deps =
     flake8
 commands =
-    flake8
+    flake8 djcelery


### PR DESCRIPTION
**Problem**

`flake8` is being run against the root directory. I think it does not make much sense as we should not be verifying dependencies that are installed under `.tox` directory, e.g.:

```
./.tox/flake8/lib/python2.7/os.py:35:0: E302 expected 2 blank lines, found 1
```

**Solution**

Only 'flake8' the `djcelery` package. This should improve the travis build time by up to 2 minutes.