### PR TITLE
Fixed a bunch of django 2.0 deprecations.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -45,6 +45,10 @@
 
     Fix contributed by Lev Berman
 
+- Fixed some django 2.0 deprecations.
+
+    Fix contributed by Éloi Rivard
+
 .. _version-3.1.17:
 
 3.1.17

--- a/djcelery/migrations/0001_initial.py
+++ b/djcelery/migrations/0001_initial.py
@@ -59,8 +59,8 @@ class Migration(migrations.Migration):
                 ('total_run_count', models.PositiveIntegerField(default=0, editable=False)),
                 ('date_changed', models.DateTimeField(auto_now=True)),
                 ('description', models.TextField(verbose_name='description', blank=True)),
-                ('crontab', models.ForeignKey(blank=True, to='djcelery.CrontabSchedule', help_text='Use one of interval/crontab', null=True, verbose_name='crontab')),
-                ('interval', models.ForeignKey(verbose_name='interval', blank=True, to='djcelery.IntervalSchedule', null=True)),
+                ('crontab', models.ForeignKey(blank=True, to='djcelery.CrontabSchedule', help_text='Use one of interval/crontab', null=True, verbose_name='crontab', on_delete=models.CASCADE)),
+                ('interval', models.ForeignKey(verbose_name='interval', blank=True, to='djcelery.IntervalSchedule', null=True, on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name': 'periodic task',
@@ -157,7 +157,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='taskstate',
             name='worker',
-            field=models.ForeignKey(verbose_name='worker', to='djcelery.WorkerState', null=True),
+            field=models.ForeignKey(verbose_name='worker', to='djcelery.WorkerState', null=True, on_delete=models.CASCADE),
             preserve_default=True,
         ),
     ]

--- a/djcelery/models.py
+++ b/djcelery/models.py
@@ -215,9 +215,11 @@ class PeriodicTask(models.Model):
     interval = models.ForeignKey(
         IntervalSchedule,
         null=True, blank=True, verbose_name=_('interval'),
+        on_delete=models.CASCADE,
     )
     crontab = models.ForeignKey(
         CrontabSchedule, null=True, blank=True, verbose_name=_('crontab'),
+        on_delete=models.CASCADE,
         help_text=_('Use one of interval/crontab'),
     )
     args = models.TextField(
@@ -352,6 +354,7 @@ class TaskState(models.Model):
     retries = models.IntegerField(_('number of retries'), default=0)
     worker = models.ForeignKey(
         WorkerState, null=True, verbose_name=_('worker'),
+        on_delete=models.CASCADE,
     )
     hidden = models.BooleanField(editable=False, default=False, db_index=True)
 


### PR DESCRIPTION
Fixed some warning you can see if you run the tests with `python -Wall tests/manage.py test`.
The [django documentation](https://docs.djangoproject.com/en/1.10/ref/models/fields/#foreignkey) tells that the field "on_delete" will be mandatory on foreign keys. The default value is `models.CASCADE`.