### PR TITLE
Update Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,13 @@ matrix:
     fast_finish: true
 
 install:
-    # Virtualenv < 14 is required to keep the Python 3.2 builds running.
-    - pip install tox "virtualenv<14"
+    - travis_retry pip install tox
 
 script:
     - tox
 
 after_success:
-    - pip install codecov
-    - codecov -e TOXENV
+    - bash <(curl -s https://codecov.io/bash)
 
 notifications:
     email: false


### PR DESCRIPTION
There is no Python 3.2 anymore.

Coverage command is taken from here - https://codecov.io/github/celery/django-celery