### PR TITLE
Resolved some warnings in tests.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -49,6 +49,10 @@
 
     Fix contributed by Éloi Rivard
 
+- Resolved some deprecation warnings in the test suite.
+
+    Fix contributed by Vytis Banaitis.
+
 .. _version-3.1.17:
 
 3.1.17

--- a/djcelery/loaders.py
+++ b/djcelery/loaders.py
@@ -190,7 +190,8 @@ def find_related_module(app, related_name):
         return
 
     try:
-        imp.find_module(related_name, app_path)
+        f, _, _ = imp.find_module(related_name, app_path)
+        f.close()
     except ImportError:
         return
 

--- a/djcelery/tests/test_schedulers.py
+++ b/djcelery/tests/test_schedulers.py
@@ -85,9 +85,9 @@ class test_ModelEntry(unittest.TestCase):
         self.assertTrue(e.schedule)
         self.assertEqual(e.total_run_count, 0)
         self.assertIsInstance(e.last_run_at, datetime)
-        self.assertDictContainsSubset({'queue': 'xaz',
-                                       'exchange': 'foo',
-                                       'routing_key': 'cpu'}, e.options)
+        self.assertEqual(e.options.get('queue'), 'xaz')
+        self.assertEqual(e.options.get('exchange'), 'foo')
+        self.assertEqual(e.options.get('routing_key'), 'cpu')
 
         right_now = celery.now()
         m2 = create_model_interval(schedule(timedelta(seconds=10)),

--- a/djcelery/tests/test_views.py
+++ b/djcelery/tests/test_views.py
@@ -5,7 +5,7 @@ import sys
 from functools import partial
 
 from billiard.einfo import ExceptionInfo
-from django.core.urlresolvers import reverse
+
 from django.http import HttpResponse
 from django.test.testcases import TestCase as DjangoTestCase
 from django.template import TemplateDoesNotExist
@@ -19,6 +19,11 @@ from celery.utils import gen_unique_id, get_full_cls_name
 
 from djcelery.views import task_webhook
 from djcelery.tests.req import MockRequest
+
+try:
+    from django.urls import reverse  # Django 1.10+
+except ImportError:
+    from django.core.urlresolvers import reverse
 
 
 def reversestar(name, **kwargs):
@@ -77,13 +82,10 @@ class ViewTestCase(DjangoTestCase):
         except AttributeError:
             self.assertTrue(expected in source)
 
-    def assertDictContainsSubset(self, a, b, *args):
-        try:
-            DjangoTestCase.assertDictContainsSubset(self, a, b, *args)
-        except AttributeError:
-            for key, value in a.items():
-                self.assertTrue(key in b)
-                self.assertEqual(b[key], value)
+    def assertDictContainsSubset(self, subset, dictionary, *args):
+        for key, value in subset.items():
+            self.assertIn(key, dictionary)
+            self.assertEqual(dictionary[key], value)
 
 
 class test_task_apply(ViewTestCase):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -8,8 +8,9 @@ warnings.filterwarnings(
     RuntimeWarning, r'django\.db\.models\.fields')
 
 # import source code dir
-sys.path.insert(0, os.getcwd())
-sys.path.insert(0, os.path.join(os.getcwd(), os.pardir))
+here = os.path.abspath(os.path.dirname(__file__))
+sys.path.insert(0, here)
+sys.path.insert(0, os.path.join(here, os.pardir))
 
 import djcelery  # noqa
 djcelery.setup_loader()
@@ -19,7 +20,6 @@ NO_NOSE = os.environ.get('DJCELERY_NO_NOSE', False)
 SITE_ID = 300
 
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 
 ROOT_URLCONF = 'tests.urls'
 SECRET_KEY = 'skskqlqlaskdsd'
@@ -32,7 +32,7 @@ AUTOCOMMIT = True
 
 if not NO_NOSE:
     TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
-here = os.path.abspath(os.path.dirname(__file__))
+
 COVERAGE_EXCLUDE_MODULES = (
     'djcelery',
     'djcelery.tests.*',
@@ -84,6 +84,13 @@ CACHES = {
     },
 }
 
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+    },
+]
+
 INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -101,4 +108,4 @@ CELERY_SEND_TASK_ERROR_EMAILS = False
 
 USE_TZ = True
 TIME_ZONE = 'UTC'
-MIDDLEWARE_CLASSES = []
+MIDDLEWARE = MIDDLEWARE_CLASSES = []

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-django{1.8,1.9,1.10}, py33-django1.8, py{34,35}-django{1.8,1.9,1.10},flake8
+envlist = py27-django{1.8,1.9,1.10}, py33-django1.8, py{34,35}-django{1.8,1.9,1.10}, flake8
 
 [testenv]
 sitepackages = False
@@ -14,7 +14,7 @@ setenv =
     PYTHONPATH={toxinidir}/tests
     DJANGO_SETTINGS_MODULE=settings
 commands =
-    {posargs:python tests/manage.py test}
+    {envpython} -Wall tests/manage.py test {posargs}
 
 [testenv:flake8]
 basepython = python2.7


### PR DESCRIPTION
Also, added `-Wall` to tox config so that all warnings would be reported.

Resolved warnings:
```
RemovedInDjango110Warning: You haven't defined a TEMPLATES setting. You must do so before upgrading to Django 1.10. Otherwise Django will be unable to load templates.
RemovedInDjango20Warning: Importing from django.core.urlresolvers is deprecated in favor of django.urls.
RemovedInDjango20Warning: Old-style middleware using settings.MIDDLEWARE_CLASSES is deprecated. Update your middleware and use settings.MIDDLEWARE instead.
DeprecationWarning: assertDictContainsSubset is deprecated
ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/vytis/src/django-celery/tests/someapp/tasks.py' mode='U' encoding='utf-8'>
```