### PR TITLE
fix django.db.backends import in patch_thread_ident

### DIFF
--- a/djcelery/management/base.py
+++ b/djcelery/management/base.py
@@ -36,9 +36,11 @@ def patch_thread_ident():
 
     if 'validate_thread_sharing' in BaseDatabaseWrapper.__dict__:
         try:
+            # py 2.x
             import thread
         except ImportError:
-            return
+            # py 3.x
+            import _thread as thread
         _get_ident = thread.get_ident
 
         __old__init__ = BaseDatabaseWrapper.__init__

--- a/djcelery/management/base.py
+++ b/djcelery/management/base.py
@@ -22,34 +22,45 @@ def patch_thread_ident():
     # -- patch taken from gunicorn
     if getattr(patch_thread_ident, 'called', False):
         return
+
     try:
-        from django.db.backends import BaseDatabaseWrapper, DatabaseError
-
-        if 'validate_thread_sharing' in BaseDatabaseWrapper.__dict__:
-            import thread
-            _get_ident = thread.get_ident
-
-            __old__init__ = BaseDatabaseWrapper.__init__
-
-            def _init(self, *args, **kwargs):
-                __old__init__(self, *args, **kwargs)
-                self._thread_ident = _get_ident()
-
-            def _validate_thread_sharing(self):
-                if (not self.allow_thread_sharing and
-                        self._thread_ident != _get_ident()):
-                    raise DatabaseError(
-                        DB_SHARED_THREAD % (
-                            self.alias, self._thread_ident, _get_ident()),
-                    )
-
-            BaseDatabaseWrapper.__init__ = _init
-            BaseDatabaseWrapper.validate_thread_sharing = \
-                _validate_thread_sharing
-
-        patch_thread_ident.called = True
+        # django >= 1.8
+        from django.db.backends.base.base import (BaseDatabaseWrapper,
+                                                  DatabaseError)
     except ImportError:
-        pass
+        try:
+            # django < 1.8
+            from django.db.backends import BaseDatabaseWrapper, DatabaseError
+        except ImportError:
+            return
+
+    if 'validate_thread_sharing' in BaseDatabaseWrapper.__dict__:
+        try:
+            import thread
+        except ImportError:
+            return
+        _get_ident = thread.get_ident
+
+        __old__init__ = BaseDatabaseWrapper.__init__
+
+        def _init(self, *args, **kwargs):
+            __old__init__(self, *args, **kwargs)
+            self._thread_ident = _get_ident()
+
+        def _validate_thread_sharing(self):
+            if (not self.allow_thread_sharing and
+                    self._thread_ident != _get_ident()):
+                raise DatabaseError(
+                    DB_SHARED_THREAD % (
+                        self.alias, self._thread_ident, _get_ident()),
+                )
+
+        BaseDatabaseWrapper.__init__ = _init
+        BaseDatabaseWrapper.validate_thread_sharing = \
+            _validate_thread_sharing
+
+    patch_thread_ident.called = True
+
 patch_thread_ident()
 
 


### PR DESCRIPTION
BaseDatabaseWrapper and DatabaseError were moved to django.db.backends.base.base package since django 1.8.

https://github.com/django/django/commit/28308078f397d1de36fd0da417ac7da2544ba12d#diff-53fcf3ac0535307033e0cfabb85c5301
