### PR TITLE
Show number of syncing entries in the log

### DIFF
--- a/djcelery/schedulers.py
+++ b/djcelery/schedulers.py
@@ -198,7 +198,7 @@ class DatabaseScheduler(Scheduler):
         return new_entry
 
     def sync(self):
-        info('Writing entries...')
+        info('Writing entries (%s)...' % len(self._dirty))
         _tried = set()
         try:
             with commit_on_success():

--- a/djcelery/schedulers.py
+++ b/djcelery/schedulers.py
@@ -198,7 +198,7 @@ class DatabaseScheduler(Scheduler):
         return new_entry
 
     def sync(self):
-        info('Writing entries (%s)...' % len(self._dirty))
+        info('Writing entries (%s)...', len(self._dirty))
         _tried = set()
         try:
             with commit_on_success():


### PR DESCRIPTION
Useful for debugging purposes; it's nice to know whether any tasks are actually being sync'ed.