### PR TITLE
PeriodicTaskAdmin enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ Documentation/
 cover/
 coverage.xml
 nosetests.xml
+djcelery-test-db
+.idea/

--- a/Changelog
+++ b/Changelog
@@ -53,6 +53,18 @@
 
     Fix contributed by Vytis Banaitis.
 
+- PeriodicTask admin list view changes:
+
+    - ``task``, ``args``, ``kwargs`` fields added to ``list_display``.
+
+    - Added ability to search tasks by ``name`` and ``task``.
+
+    - Tasks now ordered by ``('-enabled', 'name')``.
+
+    - Added enable/disable actions.
+
+    Contributed by Armenak Baburyan.
+
 .. _version-3.1.17:
 
 3.1.17

--- a/djcelery/admin.py
+++ b/djcelery/admin.py
@@ -320,7 +320,15 @@ class PeriodicTaskForm(forms.ModelForm):
 class PeriodicTaskAdmin(admin.ModelAdmin):
     form = PeriodicTaskForm
     model = PeriodicTask
-    list_display = ('__unicode__', 'enabled')
+    list_display = (
+        'enabled',
+        '__unicode__',
+        'task',
+        'args',
+        'kwargs',
+    )
+    search_fields = ('name', 'task')
+    ordering = ('-enabled', 'name')
     fieldsets = (
         (None, {
             'fields': ('name', 'regtask', 'task', 'enabled'),
@@ -339,6 +347,16 @@ class PeriodicTaskAdmin(admin.ModelAdmin):
             'classes': ('extrapretty', 'wide', 'collapse'),
         }),
     )
+    actions = ['enable_tasks',
+               'disable_tasks']
+
+    @action(_('Enable selected periodic tasks'))
+    def enable_tasks(self, request, queryset):
+        queryset.update(enabled=True)
+
+    @action(_('Disable selected periodic tasks'))
+    def disable_tasks(self, request, queryset):
+        queryset.update(enabled=False)
 
     def changelist_view(self, request, extra_context=None):
         extra_context = extra_context or {}

--- a/djcelery/tests/test_admin.py
+++ b/djcelery/tests/test_admin.py
@@ -1,0 +1,80 @@
+from __future__ import unicode_literals
+
+from django.contrib import admin
+from django.test import RequestFactory, TestCase
+
+from djcelery.admin import PeriodicTaskAdmin
+from djcelery.models import PeriodicTask, IntervalSchedule, PERIOD_CHOICES
+
+
+class MockRequest(object):
+    pass
+
+request = MockRequest()
+
+site = admin.AdminSite()
+
+
+class TestPeriodicTaskAdmin(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.interval = IntervalSchedule.objects.create(
+            every=1, period=PERIOD_CHOICES[0][0])
+
+        cls.request_factory = RequestFactory()
+
+        cls.pt_admin = PeriodicTaskAdmin(PeriodicTask, site)
+
+    def test_specified_ordering(self):
+        """
+        Ordering should be by ('-enabled', 'name')
+        """
+        PeriodicTask.objects.bulk_create([
+            PeriodicTask(name='Bohemian Rhapsody', task='bohemian_rhapsody',
+                         interval=self.interval, enabled=True),
+            PeriodicTask(name='Somebody to Love', task='somebody_to_love',
+                         interval=self.interval, enabled=False),
+            PeriodicTask(name='Tie Your Mother Down',
+                         task='tie_your_mother_down',
+                         interval=self.interval, enabled=False),
+            PeriodicTask(name='Under Pressure', task='under_pressure',
+                         interval=self.interval, enabled=True),
+        ])
+        names = [b.name for b in self.pt_admin.get_queryset(request)]
+        self.assertListEqual(['Bohemian Rhapsody', 'Under Pressure',
+                              'Somebody to Love', 'Tie Your Mother Down'],
+                             names)
+
+    def test_enable_tasks_should_enable_disabled_periodic_tasks(self):
+        """
+        enable_tasks action should enable selected periodic tasks
+        """
+        PeriodicTask.objects.create(name='Killer Queen', task='killer_queen',
+                                    interval=self.interval, enabled=False),
+        queryset = PeriodicTask.objects.filter(pk=1)
+        self.pt_admin.enable_tasks(request, queryset)
+        self.assertTrue(PeriodicTask.objects.get(pk=1).enabled)
+
+    def test_disable_tasks_should_disable_enabled_periodic_tasks(self):
+        """
+        disable_tasks action should disable selected periodic tasks
+        """
+        PeriodicTask.objects.create(name='Killer Queen', task='killer_queen',
+                                    interval=self.interval, enabled=True),
+        queryset = PeriodicTask.objects.filter(pk=1)
+        self.pt_admin.disable_tasks(request, queryset)
+        self.assertFalse(PeriodicTask.objects.get(pk=1).enabled)
+
+    def test_for_valid_search_fields(self):
+        """
+        Valid search fields should be ('name', 'task')
+        """
+        search_fields = self.pt_admin.search_fields
+        self.assertEqual(search_fields, ('name', 'task'))
+
+        for fieldname in search_fields:
+            query = '%s__icontains' % fieldname
+            kwargs = {query: 'Queen'}
+            # We have no content, so the number of results if we search on
+            # something should be zero.
+            self.assertEquals(PeriodicTask.objects.filter(**kwargs).count(), 0)


### PR DESCRIPTION
Add enable/disable actions in PeriodicTaskAdmin. Extend list_display
and search_fields. Write unit tests.

This also contains #427 and #357 