### PR TITLE
Update PeriodicTasks on bulk task enable/disable in admin.

### DIFF
--- a/djcelery/admin.py
+++ b/djcelery/admin.py
@@ -23,6 +23,7 @@ from .admin_utils import action, display_field, fixedwidth
 from .models import (
     TaskState, WorkerState,
     PeriodicTask, IntervalSchedule, CrontabSchedule,
+    PeriodicTasks
 )
 from .humanize import naturaldate
 from .utils import is_database_scheduler, make_aware
@@ -350,13 +351,20 @@ class PeriodicTaskAdmin(admin.ModelAdmin):
     actions = ['enable_tasks',
                'disable_tasks']
 
+    def update_periodic_tasks(self):
+        dummy_periodic_task = PeriodicTask()
+        dummy_periodic_task.no_changes = False
+        PeriodicTasks.changed(dummy_periodic_task)
+
     @action(_('Enable selected periodic tasks'))
     def enable_tasks(self, request, queryset):
         queryset.update(enabled=True)
+        self.update_periodic_tasks()
 
     @action(_('Disable selected periodic tasks'))
     def disable_tasks(self, request, queryset):
         queryset.update(enabled=False)
+        self.update_periodic_tasks()
 
     def changelist_view(self, request, extra_context=None):
         extra_context = extra_context or {}

--- a/djcelery/tests/test_admin.py
+++ b/djcelery/tests/test_admin.py
@@ -4,7 +4,9 @@ from django.contrib import admin
 from django.test import RequestFactory, TestCase
 
 from djcelery.admin import PeriodicTaskAdmin
-from djcelery.models import PeriodicTask, IntervalSchedule, PERIOD_CHOICES
+from djcelery.models import (
+    PeriodicTask, IntervalSchedule, PERIOD_CHOICES, PeriodicTasks
+)
 
 
 class MockRequest(object):
@@ -52,8 +54,11 @@ class TestPeriodicTaskAdmin(TestCase):
         PeriodicTask.objects.create(name='Killer Queen', task='killer_queen',
                                     interval=self.interval, enabled=False),
         queryset = PeriodicTask.objects.filter(pk=1)
+        last_update = PeriodicTasks.objects.get(ident=1).last_update
         self.pt_admin.enable_tasks(request, queryset)
+        new_last_update = PeriodicTasks.objects.get(ident=1).last_update
         self.assertTrue(PeriodicTask.objects.get(pk=1).enabled)
+        self.assertNotEqual(last_update, new_last_update)
 
     def test_disable_tasks_should_disable_enabled_periodic_tasks(self):
         """


### PR DESCRIPTION
# Problem

When selecting the admin action "Enable/Disable selected periodic tasks", celery beat is not aware of the update and continues executing newly disabled periodic tasks and ignoring newly enabled periodic tasks.

# Solution

Call PeriodicTasks.changed after the update is performed.

# Remaining Question

PeriodicTask.save is overriden in djcelery, so I'm unsure if djcelery should be calling the .save() method instead of doing a bulk update of the enabled flag.