### PR TITLE
Fixes close method call when imp returns None in loaders

### DIFF
--- a/djcelery/admin.py
+++ b/djcelery/admin.py
@@ -239,6 +239,7 @@ class WorkerMonitor(ModelMonitor):
         actions.pop('delete_selected', None)
         return actions
 
+
 admin.site.register(TaskState, TaskMonitor)
 admin.site.register(WorkerState, WorkerMonitor)
 

--- a/djcelery/loaders.py
+++ b/djcelery/loaders.py
@@ -191,7 +191,8 @@ def find_related_module(app, related_name):
 
     try:
         f, _, _ = imp.find_module(related_name, app_path)
-        f.close()
+        # f is returned None when app_path is a module
+        f and f.close()
     except ImportError:
         return
 

--- a/djcelery/management/base.py
+++ b/djcelery/management/base.py
@@ -50,6 +50,8 @@ def patch_thread_ident():
         patch_thread_ident.called = True
     except ImportError:
         pass
+
+
 patch_thread_ident()
 
 

--- a/djcelery/models.py
+++ b/djcelery/models.py
@@ -295,6 +295,7 @@ class PeriodicTask(models.Model):
         if self.crontab:
             return self.crontab.schedule
 
+
 signals.pre_delete.connect(PeriodicTasks.changed, sender=PeriodicTask)
 signals.pre_save.connect(PeriodicTasks.changed, sender=PeriodicTask)
 

--- a/djcelery/mon.py
+++ b/djcelery/mon.py
@@ -72,5 +72,6 @@ def main(argv=sys.argv):
     management.call_command('migrate')
     run_monitor(argv)
 
+
 if __name__ == '__main__':
     main()

--- a/djcelery/picklefield.py
+++ b/djcelery/picklefield.py
@@ -117,6 +117,7 @@ class PickledObjectField(BaseField):
         return super(PickledObjectField, self) \
             .get_db_prep_lookup(*args, **kwargs)
 
+
 try:
     from south.modelsinspector import add_introspection_rules
 except ImportError:

--- a/djcelery/tests/test_admin.py
+++ b/djcelery/tests/test_admin.py
@@ -12,6 +12,7 @@ from djcelery.models import (
 class MockRequest(object):
     pass
 
+
 request = MockRequest()
 
 site = admin.AdminSite()

--- a/djcelery/tests/test_worker_job.py
+++ b/djcelery/tests/test_worker_job.py
@@ -21,6 +21,8 @@ def mytask(i):
 def get_db_connection(i):
     from django.db import connection
     return id(connection)
+
+
 get_db_connection.ignore_result = True
 
 


### PR DESCRIPTION
When django-celery tries to find related module from installed apps, the loading fails when `tasks` is a module inside one of the installed apps.

`imp.find_module` returns first argument as `None` if app_path is
a module and not a file

these changes will call close method only if the file is retuned

more information:
https://docs.python.org/2/library/imp.html#imp.find_module