### PR TITLE
Reduce task_id column length to 36 characters

### DIFF
--- a/djcelery/migrations/0002_shorten_task_id.py
+++ b/djcelery/migrations/0002_shorten_task_id.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('djcelery', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='taskmeta',
+            name='task_id',
+            field=models.CharField(unique=True, max_length=36, verbose_name='task id'),
+        ),
+    ]

--- a/djcelery/models.py
+++ b/djcelery/models.py
@@ -29,7 +29,7 @@ def cronexp(field):
 @python_2_unicode_compatible
 class TaskMeta(models.Model):
     """Task result/status."""
-    task_id = models.CharField(_('task id'), max_length=255, unique=True)
+    task_id = models.CharField(_('task id'), max_length=36, unique=True)
     status = models.CharField(
         _('state'),
         max_length=50, default=states.PENDING, choices=TASK_STATE_CHOICES,


### PR DESCRIPTION
It's a UUID. MySQL InnoDB can't create 255 character column indices,
when using the utf8mb4 character set, as it's limited to 767 bytes.