### PR TITLE
Fixes should_sync() test so that it passes with celery v3.1.24

### DIFF
--- a/djcelery/tests/test_schedulers.py
+++ b/djcelery/tests/test_schedulers.py
@@ -154,8 +154,9 @@ class test_DatabaseScheduler(unittest.TestCase):
     def test_should_sync(self):
         self.assertTrue(self.s.should_sync())
         self.s._last_sync = monotonic()
+        self.s._tasks_since_sync = 0
         self.assertFalse(self.s.should_sync())
-        self.s._last_sync -= self.s.sync_every
+        self.s._last_sync -= self.s.sync_every + 1
         self.assertTrue(self.s.should_sync())
 
     def test_reserve(self):


### PR DESCRIPTION
Was getting the following error:

```
nosetests /builddir/build/BUILD/django-celery-3.2.1/tests/../djcelery/tests  --cover3-package=djcelery --cover3-branch --cover3-exclude=djcelery,djcelery.tests.*,djcelery.management.*,djcelery.contrib.* --verbosity=1
Creating test database for alias 'default'...
.............................................F..........................
======================================================================
FAIL: test_should_sync (djcelery.tests.test_schedulers.test_DatabaseScheduler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/builddir/build/BUILD/django-celery-3.2.1/tests/../djcelery/tests/test_schedulers.py", line 159, in test_should_sync
    self.assertTrue(self.s.should_sync())
AssertionError: 0 is not true
-------------------- >> begin captured logging << --------------------
djcelery.schedulers: DEBUG: DatabaseScheduler: intial read
djcelery.schedulers: INFO: Writing entries (0)...
djcelery.schedulers: DEBUG: DatabaseScheduler: Fetching database schedule
djcelery.schedulers: DEBUG: Current schedule:
<ModelEntry: thefoo32 djcelery.unittest.add33(*[2, 2], **{u'callback': u'foo'}) <freq: 20.00 minutes>>
<ModelEntry: thefoo30 djcelery.unittest.add31(*[2, 2], **{u'callback': u'foo'}) <freq: 10.00 seconds>>
<ModelEntry: thefoo34 djcelery.unittest.add35(*[2, 2], **{u'callback': u'foo'}) <crontab: 2,4,5 * * * * (m/h/d/dM/MY)>>
--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
Ran 72 tests in 0.667s
```
Just submitting a small patch that makes the pass correctly (without breaking it's intentions).
