### PR TITLE
Another `celery.utils.time` fix

### DIFF
--- a/djcelery/backends/database.py
+++ b/djcelery/backends/database.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import, unicode_literals
 
 from celery import current_app
 from celery.backends.base import BaseDictBackend
-from celery.utils.timeutils import maybe_timedelta
+try:
+    from celery.utils.timeutils import maybe_timedelta
+except ImportError:
+    from celery.utils.time import maybe_timedelta
 
 from ..models import TaskMeta, TaskSetMeta
 


### PR DESCRIPTION
For bug #496
To go along with this: https://github.com/celery/django-celery/pull/516/commits/12b7646f455527d2bef51508c105137a02832cae
and this: https://github.com/celery/django-celery/pull/510