### PR TITLE
fixes rst 'unkown target' error

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,10 +71,11 @@ Documentation
 =============
 
 The `Celery User Manual`_ contains user guides, tutorials and an API
-reference. Also the `django-celery documentation`_, contains information
-about the Django integration.
+reference. It also has a dedicated `subsection about the Django integration`_.
 
 .. _`Celery User Manual`: http://docs.celeryproject.org/
+.. _`subsection about the Django integration`:
+   http://docs.celeryproject.org/en/latest/django/
 .. _`Getting started with django-celery`:
    http://docs.celeryproject.org/en/latest/django/first-steps-with-django.html
 


### PR DESCRIPTION
    $ rst2html.py --version; rst2html.py README.rst > /dev/null
     rst2html.py (Docutils 0.12 [release], Python 3.4.3, on linux)
     README.rst:73: (ERROR/3) Unknown target name: "django-celery documentation".

Based on my experience, this should also fix the formatting issue on the
pypi.python.org site

changed the link based on the intent of the original commit that removed it, 27bec1e20af79df83061105127c123715c3d1011