### PR TITLE
Improves periodic tasks admin, tasks are better clickable.

### DIFF
--- a/djcelery/admin.py
+++ b/djcelery/admin.py
@@ -330,6 +330,7 @@ class PeriodicTaskAdmin(admin.ModelAdmin):
         'kwargs',
     )
     search_fields = ('name', 'task')
+    list_display_links = ('enabled', '__unicode__', 'task')
     ordering = ('-enabled', 'name')
     fieldsets = (
         (None, {


### PR DESCRIPTION
Improves periodic tasks admin, tasks are better clickable.
Old situation: only `enabled` is clickable. This is not clear because it uses an icon. 

![image](https://user-images.githubusercontent.com/10162961/28262272-bcf5d58c-6ae2-11e7-9c28-4e9ca04f9eb3.png)

New situation, `periodic task` and `task name` are also clickable. This improves navigation in the periodic task admin: 

![image](https://user-images.githubusercontent.com/10162961/28262243-9f8d1a1e-6ae2-11e7-99d4-579af0f46126.png)


