### PR TITLE
Bump version to 3.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,14 @@ python:
 sudo: false
 
 env:
-    - TOXENV="py35-django1.9"
-    - TOXENV="py34-django1.9"
-    - TOXENV="py27-django1.9"
-    - TOXENV="py35-django1.8"
-    - TOXENV="py34-django1.8"
-    - TOXENV="py33-django1.8"
     - TOXENV="py27-django1.8"
+    - TOXENV="py35-django1.8"
+    - TOXENV="py27-django1.9"
+    - TOXENV="py35-django1.9"
     - TOXENV="py27-django1.10"
     - TOXENV="py35-django1.10"
-    - TOXENV="py34-django1.10"
+    - TOXENV="py27-django1.11"
+    - TOXENV="py35-django1.11"
     - TOXENV="flake8"
 
 matrix:

--- a/Changelog
+++ b/Changelog
@@ -7,6 +7,14 @@
 
 .. _version-3.2.0:
 
+3.2.2
+=====
+:release-date: 2017-08-04
+
+- Django 1.11 testing and support
+
+- Version bump for edX fork for proper re-installation.
+
 3.2.0
 =====
 :release-date: TDB
@@ -28,7 +36,7 @@
 - Fixed Django 1.10 compatibility issue in scheduler
 
     Fix contributed by Mathieu Fenniak.
-    
+
 - Fixed Django 1.10 compatibility issue in management commands
 
     Fix contributed by Stranger6667, yjmade and Vytis Banaitis.

--- a/djcelery/__init__.py
+++ b/djcelery/__init__.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, unicode_literals
 import os
 import sys
 
-VERSION = (3, 2, 0)
+VERSION = (3, 2, 2)
 __version__ = '.'.join(map(str, VERSION[0:3])) + ''.join(VERSION[3:])
 __author__ = 'Ask Solem'
 __contact__ = 'ask@celeryproject.org'

--- a/djcelery/tests/test_admin.py
+++ b/djcelery/tests/test_admin.py
@@ -83,4 +83,4 @@ class TestPeriodicTaskAdmin(TestCase):
             kwargs = {query: 'Queen'}
             # We have no content, so the number of results if we search on
             # something should be zero.
-            self.assertEquals(PeriodicTask.objects.filter(**kwargs).count(), 0)
+            self.assertEqual(PeriodicTask.objects.filter(**kwargs).count(), 0)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-django{1.8,1.9,1.10}, py33-django1.8, py{34,35}-django{1.8,1.9,1.10}, flake8
+envlist = py{27,35}-django{1.8,1.9,1.10,1.11}, flake8
 
 [testenv]
 sitepackages = False
@@ -9,6 +9,7 @@ deps =
     django1.8: Django>=1.8.0,<1.9.0
     django1.9: Django>=1.9.0,<1.10.0
     django1.10: Django>=1.10.0,<1.11.0
+    django1.11: Django>=1.11.0,<2.0
 
 setenv =
     PYTHONPATH={toxinidir}/tests


### PR DESCRIPTION
edx-platform will temporarily use this edX fork of django-celery until Celery is upgraded to v4.
edx-platform currently installs django-celery v3.2.1. That version was *not* on master in the upstream repo - it was on an unmerged branch:
https://github.com/celery/django-celery/compare/master...v3.2.1

This PR bumps the version on the edX fork to avoid confusion around the installation of django-celery. Bumping the version will cause installation of the edX fork version on all edx-platform installations.