### PR TITLE
Fix bug when run command `celery`

### DIFF
--- a/djcelery/db.py
+++ b/djcelery/db.py
@@ -27,7 +27,7 @@ except ImportError:  # pragma: no cover
                 transaction.managed(True, *args, **kwargs)
                 try:
                     yield
-                except:
+                except Exception:
                     if transaction.is_dirty(*args, **kwargs):
                         transaction.rollback(*args, **kwargs)
                     raise
@@ -35,7 +35,7 @@ except ImportError:  # pragma: no cover
                     if transaction.is_dirty(*args, **kwargs):
                         try:
                             transaction.commit(*args, **kwargs)
-                        except:
+                        except Exception:
                             transaction.rollback(*args, **kwargs)
                             raise
             finally:

--- a/djcelery/loaders.py
+++ b/djcelery/loaders.py
@@ -59,8 +59,8 @@ class DjangoLoader(BaseLoader):
         self.configured = True
         # Default backend needs to be the database backend for backward
         # compatibility.
-        backend = (getattr(settings, 'CELERY_RESULT_BACKEND', None) or
-                   getattr(settings, 'CELERY_BACKEND', None))
+        backend = getattr(settings, 'CELERY_RESULT_BACKEND', None)
+        backend = backend or getattr(settings, 'CELERY_BACKEND', None)
         if not backend:
             settings.CELERY_RESULT_BACKEND = 'database'
         return DictAttribute(settings)

--- a/djcelery/management/commands/celery.py
+++ b/djcelery/management/commands/celery.py
@@ -13,10 +13,7 @@ class Command(CeleryCommand):
     help = 'celery commands, see celery help'
     cc_options = CeleryCommand.options if CeleryCommand.options else []
     base_options = base.get_options() if base.get_options() else []
-    if hasattr(base, "preload_options"):
-        preload_options = base.preload_options if base.preload_options else []
-    else:
-        preload_options = []
+    preload_options = getattr(base, 'preload_options', []) or []
     options = (cc_options +
                base_options +
                preload_options)

--- a/djcelery/management/commands/celery.py
+++ b/djcelery/management/commands/celery.py
@@ -17,7 +17,6 @@ class Command(CeleryCommand):
         preload_options = base.preload_options if base.preload_options else []
     else:
         preload_options = []
-    preload_options = base.preload_options if base.preload_options else []
     options = (cc_options +
                base_options +
                preload_options)

--- a/djcelery/management/commands/celery.py
+++ b/djcelery/management/commands/celery.py
@@ -14,9 +14,7 @@ class Command(CeleryCommand):
     cc_options = CeleryCommand.options if CeleryCommand.options else []
     base_options = base.get_options() if base.get_options() else []
     preload_options = getattr(base, 'preload_options', []) or []
-    options = (cc_options +
-               base_options +
-               preload_options)
+    options = cc_options + base_options + preload_options
 
     def run_from_argv(self, argv):
         argv = self.handle_default_options(argv)

--- a/djcelery/management/commands/celerybeat.py
+++ b/djcelery/management/commands/celerybeat.py
@@ -15,10 +15,11 @@ beat = beat.beat(app=app)
 
 class Command(CeleryCommand):
     """Run the celery periodic task scheduler."""
-    options = (CeleryCommand.options +
-               beat.get_options() +
-               beat.preload_options)
     help = 'Old alias to the "celery beat" command.'
+    cc_options = CeleryCommand.options if CeleryCommand.options else []
+    beat_options = beat.get_options() if beat.get_options() else []
+    preload_options = getattr(beat, 'preload_options', []) or []
+    options = cc_options + beat_options + preload_options
 
     def handle(self, *args, **options):
         beat.run(*args, **options)

--- a/djcelery/management/commands/celerybeat.py
+++ b/djcelery/management/commands/celerybeat.py
@@ -16,10 +16,9 @@ beat = beat.beat(app=app)
 class Command(CeleryCommand):
     """Run the celery periodic task scheduler."""
     help = 'Old alias to the "celery beat" command.'
-    cc_options = CeleryCommand.options if CeleryCommand.options else []
-    beat_options = beat.get_options() if beat.get_options() else []
-    preload_options = getattr(beat, 'preload_options', []) or []
-    options = cc_options + beat_options + preload_options
+    options = CeleryCommand.options
+    options += beat.get_options()
+    options += beat.preload_options
 
     def handle(self, *args, **options):
         beat.run(*args, **options)

--- a/djcelery/management/commands/celerycam.py
+++ b/djcelery/management/commands/celerycam.py
@@ -21,6 +21,10 @@ class Command(CeleryCommand):
     preload_options = getattr(ev, 'preload_options', []) or []
     options = cc_options + ev_options + preload_options
 
+    options = CeleryCommand.options
+    options += ev.get_options()
+    options += ev.preload_options
+
     def handle(self, *args, **options):
         """Handle the management command."""
         options['camera'] = 'djcelery.snapshot.Camera'

--- a/djcelery/management/commands/celerycam.py
+++ b/djcelery/management/commands/celerycam.py
@@ -15,10 +15,11 @@ ev = events.events(app=app)
 
 class Command(CeleryCommand):
     """Run the celery curses event viewer."""
-    options = (CeleryCommand.options +
-               ev.get_options() +
-               ev.preload_options)
     help = 'Takes snapshots of the clusters state to the database.'
+    cc_options = CeleryCommand.options if CeleryCommand.options else []
+    ev_options = ev.get_options() if ev.get_options() else []
+    preload_options = getattr(ev, 'preload_options', []) or []
+    options = cc_options + ev_options + preload_options
 
     def handle(self, *args, **options):
         """Handle the management command."""

--- a/djcelery/management/commands/celerycam.py
+++ b/djcelery/management/commands/celerycam.py
@@ -16,11 +16,6 @@ ev = events.events(app=app)
 class Command(CeleryCommand):
     """Run the celery curses event viewer."""
     help = 'Takes snapshots of the clusters state to the database.'
-    cc_options = CeleryCommand.options if CeleryCommand.options else []
-    ev_options = ev.get_options() if ev.get_options() else []
-    preload_options = getattr(ev, 'preload_options', []) or []
-    options = cc_options + ev_options + preload_options
-
     options = CeleryCommand.options
     options += ev.get_options()
     options += ev.preload_options

--- a/djcelery/management/commands/celeryd.py
+++ b/djcelery/management/commands/celeryd.py
@@ -16,10 +16,9 @@ worker = worker.worker(app=app)
 class Command(CeleryCommand):
     """Run the celery daemon."""
     help = 'Old alias to the "celery worker" command.'
-    cc_options = CeleryCommand.options if CeleryCommand.options else []
-    worker_options = worker.get_options() if worker.get_options() else []
-    preload_options = getattr(worker, 'preload_options', []) or []
-    options = cc_options + worker_options + preload_options
+    options = CeleryCommand.options
+    options += worker.get_options()
+    options += worker.preload_options
 
     def handle(self, *args, **options):
         worker.check_args(args)

--- a/djcelery/management/commands/celeryd.py
+++ b/djcelery/management/commands/celeryd.py
@@ -16,9 +16,10 @@ worker = worker.worker(app=app)
 class Command(CeleryCommand):
     """Run the celery daemon."""
     help = 'Old alias to the "celery worker" command.'
-    options = (CeleryCommand.options +
-               worker.get_options() +
-               worker.preload_options)
+    cc_options = CeleryCommand.options if CeleryCommand.options else []
+    worker_options = worker.get_options() if worker.get_options() else []
+    preload_options = getattr(worker, 'preload_options', []) or []
+    options = cc_options + worker_options + preload_options
 
     def handle(self, *args, **options):
         worker.check_args(args)

--- a/djcelery/management/commands/celerymon.py
+++ b/djcelery/management/commands/celerymon.py
@@ -30,9 +30,10 @@ or if you're still using easy_install (shame on you!)
 
 class Command(CeleryCommand):
     """Run the celery monitor."""
-    options = (CeleryCommand.options +
-               (mon and mon.get_options() + mon.preload_options or ()))
     help = 'Run the celery monitor'
+    cc_options = CeleryCommand.options if CeleryCommand.options else []
+    mon_options = mon and mon.get_options() + mon.preload_options or ()
+    options = cc_options + mon_options
 
     def handle(self, *args, **options):
         """Handle the management command."""

--- a/djcelery/management/commands/celerymon.py
+++ b/djcelery/management/commands/celerymon.py
@@ -31,9 +31,8 @@ or if you're still using easy_install (shame on you!)
 class Command(CeleryCommand):
     """Run the celery monitor."""
     help = 'Run the celery monitor'
-    cc_options = CeleryCommand.options if CeleryCommand.options else []
-    mon_options = mon and mon.get_options() + mon.preload_options or ()
-    options = cc_options + mon_options
+    options = CeleryCommand.options
+    options += (mon and mon.get_options() + mon.preload_options or ())
 
     def handle(self, *args, **options):
         """Handle the management command."""

--- a/djcelery/management/commands/djcelerymon.py
+++ b/djcelery/management/commands/djcelerymon.py
@@ -32,9 +32,10 @@ class WebserverThread(threading.Thread):
 class Command(CeleryCommand):
     """Run the celery curses event viewer."""
     args = '[optional port number, or ipaddr:port]'
-    options = (runserver.Command.option_list +
-               ev.get_options() +
-               ev.preload_options)
+    c_options = runserver.Command.option_list
+    c_options += ev.get_options()
+    c_options += ev.preload_options
+
     help = 'Starts Django Admin instance and celerycam in the same process.'
     # see http://code.djangoproject.com/changeset/13319.
     stdout, stderr = sys.stdout, sys.stderr

--- a/djcelery/management/commands/djcelerymon.py
+++ b/djcelery/management/commands/djcelerymon.py
@@ -32,9 +32,9 @@ class WebserverThread(threading.Thread):
 class Command(CeleryCommand):
     """Run the celery curses event viewer."""
     args = '[optional port number, or ipaddr:port]'
-    c_options = runserver.Command.option_list
-    c_options += ev.get_options()
-    c_options += ev.preload_options
+    options = runserver.Command.option_list
+    options += ev.get_options()
+    options += ev.preload_options
 
     help = 'Starts Django Admin instance and celerycam in the same process.'
     # see http://code.djangoproject.com/changeset/13319.

--- a/djcelery/schedulers.py
+++ b/djcelery/schedulers.py
@@ -159,10 +159,11 @@ class DatabaseScheduler(Scheduler):
         self._dirty = set()
         self._finalize = Finalize(self, self.sync, exitpriority=5)
         Scheduler.__init__(self, *args, **kwargs)
-        self.max_interval = (
-            kwargs.get('max_interval') or
-            self.app.conf.CELERYBEAT_MAX_LOOP_INTERVAL or
-            DEFAULT_MAX_INTERVAL)
+        self.max_interval = kwargs.get('max_interval')
+        if self.max_interval is None:
+            self.max_interval = self.app.conf.CELERYBEAT_MAX_LOOP_INTERVAL
+        if self.max_interval is None:
+            self.max_interval = DEFAULT_MAX_INTERVAL
 
     def setup_schedule(self):
         self.install_default_entries(self.schedule)

--- a/djcelery/utils.py
+++ b/djcelery/utils.py
@@ -38,11 +38,11 @@ try:
 except ImportError:
     _oracle_database_errors = ()  # noqa
 
-DATABASE_ERRORS = ((DatabaseError, ) +
-                   _my_database_errors +
-                   _pg_database_errors +
-                   _lite_database_errors +
-                   _oracle_database_errors)
+DATABASE_ERRORS = (DatabaseError, )
+DATABASE_ERRORS += _my_database_errors
+DATABASE_ERRORS += _pg_database_errors
+DATABASE_ERRORS += _lite_database_errors
+DATABASE_ERRORS += _oracle_database_errors
 
 
 def make_aware(value):


### PR DESCRIPTION
There's a bug when run `python manage celery` related to attribute `preload_options` not existed in `CeleryCommand`.