### PR TITLE
Run management command in tox.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ setenv =
     DJANGO_SETTINGS_MODULE=settings
 commands =
     {envpython} -Wall tests/manage.py test {posargs}
+    {envpython} manage.py celery
 
 [testenv:flake8]
 basepython = python2.7


### PR DESCRIPTION
Run the `celery` management command, to detect breakage there.

This should be more exaustive (though I'm not sure which commands will work with the celery config here?), it should be enough to check if the management command fails.

NOTE:  I can't run tox here to see if this works.