### PR TITLE
issue #579. @@tx_isolation is deprecated since MYSQL 5.7.20

### DIFF
--- a/djcelery/managers.py
+++ b/djcelery/managers.py
@@ -189,7 +189,11 @@ class TaskManager(ResultManager):
     def warn_if_repeatable_read(self):
         if 'mysql' in self.current_engine().lower():
             cursor = self.connection_for_read().cursor()
-            if cursor.execute('SELECT @@tx_isolation'):
+            if self._is_mysql and self.server_version_info >= (5, 7, 20):
+                ti = cursor.execute("SELECT @@transaction_isolation")
+            else:
+                ti = cursor.execute("SELECT @@tx_isolation")
+            if ti:
                 isolation = cursor.fetchone()[0]
                 if isolation == 'REPEATABLE-READ':
                     warnings.warn(TxIsolationWarning(


### PR DESCRIPTION
`@@tx_isolation` is deprecated since MYSQL 5.7.20, we should use `@@transaction_isolation` instead
https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_tx_isolation

Fix suggested by [sqlalchemy](https://github.com/sqlalchemy/sqlalchemy/blob/rel_1_3/lib/sqlalchemy/dialects/mysql/base.py#L2193) realization 