### PR TITLE
Fix bug for adding a default value to celery.py when base.get_options return None

### DIFF
--- a/djcelery/management/commands/celery.py
+++ b/djcelery/management/commands/celery.py
@@ -13,7 +13,7 @@ class Command(CeleryCommand):
     help = 'celery commands, see celery help'
     options = (
         tuple(CeleryCommand.options) +
-        tuple(base.get_options()) +
+        tuple(base.get_options() or ()) +
         tuple(getattr(base, 'preload_options', ()))
     )
 


### PR DESCRIPTION
You can see diff information.
<pre>
<--

diff --git a/djcelery/management/commands/celery.py b/djcelery/management/commands/celery.py
index 0ee878d..82cf303 100644
--- a/djcelery/management/commands/celery.py
+++ b/djcelery/management/commands/celery.py
@@ -13,7 +13,7 @@ class Command(CeleryCommand):
     help = 'celery commands, see celery help'
     options = (
         tuple(CeleryCommand.options) +
-        tuple(base.get_options()) +
+        tuple(base.get_options() or ()) +
         tuple(getattr(base, 'preload_options', ()))
     )

-->
</pre>