### PR TITLE
Fix broken wiki links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -150,7 +150,7 @@ to our issue tracker at http://github.com/celery/django-celery/issues/
 Wiki
 ====
 
-http://wiki.github.com/celery/celery/
+https://github.com/celery/celery/wiki
 
 Contributing
 ============

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -167,7 +167,7 @@ to our issue tracker at http://github.com/celery/django-celery/issues/
 Wiki
 ====
 
-http://wiki.github.com/celery/celery/
+https://github.com/celery/celery/wiki
 
 Contributing
 ============


### PR DESCRIPTION
I know this package is no longer recommended, so I'm not sure if anyone cares, but I was looking through the readme and discovered that the wiki link is broken. Making an educated guess about where it's supposed to go.